### PR TITLE
Only remove quote if regex not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talonjs",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Javascript port of the Mailgun/Talon library.",
   "main": "bin/Talon.js",
   "repository": "https://github.com/quentez/talonjs",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -4,8 +4,8 @@ export const ContentTypeTextPlain: ContentType = "text/plain";
 export const ContentTypeTextHtml: ContentType = "text/html";
 
 export const SplitterMaxLines = 4;
-export const MaxLinesCount = 1000;
-export const NodeLimit = 1000;
+export const MaxLinesCount = 4000;
+export const NodeLimit = 4000;
 
 export const QuoteIds = ["OLK_SRC_BODY_SECTION"];
 

--- a/src/HtmlQuotations.ts
+++ b/src/HtmlQuotations.ts
@@ -58,6 +58,7 @@ export function deleteQuotationTags(document: Document, element: Node, quotation
   isTagInQuotation: boolean
 } {
   let isTagInQuotation = true;
+
   // Check if this element is a quotation tag.
   if (quotationCheckpoints[count]) {
     if (element.firstChild && element.firstChild.nodeType === NodeTypes.TEXT_NODE)
@@ -111,18 +112,23 @@ export function deleteQuotationTags(document: Document, element: Node, quotation
     isTagInQuotation
   };
 }
-export interface cutQuoteOption {
+
+export interface CutQuoteOption {
   onlyRemoveEmptyBlocks?: boolean
+}
+
+function shouldNotRemoveQuote(node: Node, options?: CutQuoteOption): Boolean {
+  return Boolean(options && options.onlyRemoveEmptyBlocks && node.textContent.trim() !== '');
 }
 
 /**
  * Cuts the outermost block element with the class "gmail_quote".
  *
  * @param {Document} document - The document to cut the element from.
- * @param {cutQuoteOption} options - Extra options.
+ * @param {CutQuoteOption} options - Extra options.
  * @return {boolean} Whether a corresponding quote was found or not.
  */
-export function cutGmailQuote(document: Document, options?: cutQuoteOption): boolean {
+export function cutGmailQuote(document: Document, options?: CutQuoteOption): boolean {
   // Find the first element that fits our criteria.
   const gmailQuote = <Node>XPath.select("//*[contains(@class, 'gmail_quote')]", document, true);
 
@@ -135,17 +141,14 @@ export function cutGmailQuote(document: Document, options?: cutQuoteOption): boo
   return true;
 };
 
-function shouldNotRemoveQuote(node: Node, options?: cutQuoteOption) {
-  return options && options.onlyRemoveEmptyBlocks && node.textContent.trim() !== '';
-}
 /**
  * Cuts the Outlook splitter block and all the following block.
  *
  * @param {Document} document - The document to cut the elements from.
- * @param {cutQuoteOption} options - Extra options.
+ * @param {CutQuoteOption} options - Extra options.
  * @return {boolean} Whether a corresponding quote was found or not.
  */
-export function cutMicrosoftQuote(document: Document, options?: cutQuoteOption): boolean {
+export function cutMicrosoftQuote(document: Document, options?: CutQuoteOption): boolean {
   let splitter = <Node>XPath.select(
     // Outlook 2007, 2010.
     "//*[local-name(.)='div' and @style='border:none;" +
@@ -199,10 +202,10 @@ export function cutMicrosoftQuote(document: Document, options?: cutQuoteOption):
  * Cuts a Zimbra quote block.
  *
  * @param {Document} document - The document to cut the element from.
- * @param {cutQuoteOption} options - Extra options.
+ * @param {CutQuoteOption} options - Extra options.
  * @return {boolean} Whether a corresponding quote was found or not.
  */
-export function cutZimbraQuote(document: Document, options?: cutQuoteOption): boolean {
+export function cutZimbraQuote(document: Document, options?: CutQuoteOption): boolean {
   const splitter = <Node>XPath.select("//*[local-name(.)='hr' and @data-marker=\"__DIVIDER__\"]", document, true);
   if (!splitter || shouldNotRemoveQuote(splitter, options))
     return false;
@@ -215,10 +218,10 @@ export function cutZimbraQuote(document: Document, options?: cutQuoteOption): bo
  * Cuts all of the outermost block elements with known quote ids.
  *
  * @param {Document} document - The document to cut the element from.
- * @param {cutQuoteOption} options - Extra options.
+ * @param {CutQuoteOption} options - Extra options.
  * @return {boolean} Whether a corresponding quote was found or not.
  */
-export function cutById(document: Document, options?: cutQuoteOption): boolean {
+export function cutById(document: Document, options?: CutQuoteOption): boolean {
   let found = false;
 
   // For each known Quote Id, remove any corresponding element.
@@ -239,10 +242,10 @@ export function cutById(document: Document, options?: cutQuoteOption): boolean {
  * Cust the last non-nested blockquote with wrapping elements.
  *
  * @param {Document} document - The document to cut the element from.
- * @param {cutQuoteOption} options - Extra options.
+ * @param {CutQuoteOption} options - Extra options.
  * @return {boolean} Whether a corresponding quote was found or not.
  */
-export function cutBlockquote(document: Document, options?: cutQuoteOption): boolean {
+export function cutBlockquote(document: Document, options?: CutQuoteOption): boolean {
   const quote = <Node>XPath.select(
     "(.//*[local-name(.)='blockquote'])" +
     "[not(@class=\"gmail_quote\") and not(ancestor::blockquote)]" +

--- a/src/HtmlQuotations.ts
+++ b/src/HtmlQuotations.ts
@@ -43,18 +43,14 @@ export function addCheckpoint(document: Document, element: Node, count: number =
   return count;
 };
 
-
 /**
  * Remove tags with quotation checkpoints from the provided HTML element and all its descendants.
- * Only remove the child under the first quotation occurence
  *
  * @param {Document} document - The DOM document.
  * @param {Node} element - The HTML element to edit.
  * @param {boolean[]} quotationCheckpoints - The checkpoints for the tags to remove.
- * @param {StartQuoteInfo} startQuoteInfo - Info of the quote we want to remove
  * @param {number} count - The number of scanned tags.
  * @param {number} level - The recursion call depth.
- * @param {boolean} isBlockQuote - Is the current node part of a bloqkquote element
  * @return {object} The updated count, and whether this tag was part of a quote or not.
  */
 export function deleteQuotationTags(document: Document, element: Node, quotationCheckpoints: boolean[], count: number = 0, level: number = 0): {

--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -147,7 +147,6 @@ interface ExtractQuoteOptions {
   ignoreBlockTags?: boolean
 }
 
-
 interface ExtractQuoteResult {
   quotationCheckpoints?: Array<boolean>,
   quoteWasFound?: boolean,

--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -10,7 +10,7 @@ import {
   cutMicrosoftQuote,
   cutZimbraQuote,
   deleteQuotationTags,
-  cutQuoteOption
+  CutQuoteOption
 } from './HtmlQuotations';
 import {
   CheckPointRegexp,
@@ -127,7 +127,7 @@ export function extractFromHtml(messageBody: string): ExtractFromHtmlResult {
    // Try and cut the quote of one of the known types.
    const cutQuotations = cutQuotation(xmlDocumentCopy);
 
-  // Otherwise, if we found a known quote earlier, return the content before.
+  //If we found a known quote earlier, return the content before.
   if (cutQuotations)
     return { body: xmlDomSerializer.serializeToString(xmlDocumentCopy, true), didFindQuote: true };
   // Finally, if no quote was found, return the original HTML.
@@ -135,7 +135,7 @@ export function extractFromHtml(messageBody: string): ExtractFromHtmlResult {
     return { body: messageBody, didFindQuote: false };
 }
 
-function cutQuotation(xmlDocument: Document, options?: cutQuoteOption) {
+function cutQuotation(xmlDocument: Document, options?: CutQuoteOption) {
   return cutGmailQuote(xmlDocument, options)
   || cutZimbraQuote(xmlDocument, options)
   || cutBlockquote(xmlDocument, options)
@@ -247,6 +247,7 @@ export function markMessageLines(lines: string[]): string {
   let index = 0;
   while (index < lines.length) {
     const line = lines[index];
+
     // Empty line.
     if (!line) {
       markers[index] = "e";

--- a/src/Regexp.ts
+++ b/src/Regexp.ts
@@ -7,7 +7,7 @@ export const DelimiterRegexp = new RegExp("\\r?\\n");
 export const ForwardRegexp = new RegExp("^[-]+[ ]*Forwarded message[ ]*[-]+$", "im");
 
 export const OnDateSomebodyWroteRegexp = new RegExp(
-  `-{0,100}[>]?[ ]?(${
+  `-{0,100}[>]?[\\s]?(${
     // Beginning of the line.
     [
       "On",       // English,
@@ -16,9 +16,10 @@ export const OnDateSomebodyWroteRegexp = new RegExp(
       "Op",       // Dutch
       "Am",       // German
       "På",       // Norwegian
-      "Den"       // Swedish, Danish
+      "Den",      // Swedish, Danish,
+      "Em"        // Portuguese
     ].join("|")
-  })[ ].{0,100}(${
+  })[\\s].{0,100}(${
     // Date and sender separator.
     [
       ",",          // Most languages separate date and sender address by comma.
@@ -32,19 +33,20 @@ export const OnDateSomebodyWroteRegexp = new RegExp(
       "napisał",                          // Polish
       "schreef", "verzond", "geschreven", // Dutch
       "schrieb",                          // German
-      "skrev"                             // Norwegian, Swedish
+      "skrev" ,                           // Norwegian, Swedish
+      "escreveu"                          // Portuguese
     ].join("|")
   }):?-{0,100}`
 );
 
 export const OnDateWroteSomebodyRegexp = new RegExp(
-  `-{0,100}[>]?[ ]?(${
+  `-{0,100}[>]?[\\s]?(${
     // Beginning of the line.
     [
       "Op",
       "Am"  // German
     ].join("|")
-  })[ ].{0,100}(.*\\n){0,2}.{0,100}(${
+  })[\\s].{0,100}(.*\\n){0,2}.{0,100}(${
     // Ending of the line.
     [
       "schreef", "verzond", "geschreven", // Dutch

--- a/tests/fixtures/front/email_with_quote.html
+++ b/tests/fixtures/front/email_with_quote.html
@@ -1,0 +1,62 @@
+<div dir="ltr">
+  <div dir="ltr">
+    <div>
+      <div dir="ltr" class="gmail_signature" data-smartmail="gmail_signature"></div>
+    </div>If you just read this
+  </div>
+  <div dir="ltr">
+    <div dir="ltr" class="gmail_attr"><br></div>
+    <blockquote class="gmail_quote"
+      style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">
+      <div class="gmail-m_6323339324984540685main-style-6ddc6ddc57bd45f0d259">
+        <div>Too often, how we work with people outside our organization and how we collaborate internally with our team
+          are like night and day. Different apps, different processes, different… everything. Keeping everyone in the
+          loop is like playing telephone, and you waste time relaying updates instead of moving forward together.</div>
+      </div>
+    </blockquote>
+  </div>
+  <div dir="ltr">
+    <div><br></div>
+    <div>you will not realize that you are missing text</div>
+  </div>
+  <div><br></div>
+  <div class="gmail_quote">
+    <div dir="ltr" class="gmail_attr">On Fri, May 3, 2019 at 10:43 AM Ailian Gan &lt;<a
+        href="mailto:ailian@frontapp.com">ailian@frontapp.com</a>&gt; wrote:<br></div>
+    <blockquote class="gmail_quote"
+      style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">
+      <div class="gmail-m_6323339324984540685main-style-6ddc6ddc57bd45f0d259">
+        <div>Too often, how we work with people outside our organization and how we collaborate internally with our team
+          are like night and day. Different apps, different processes, different… everything. Keeping everyone in the
+          loop is like playing telephone, and you waste time relaying updates instead of moving forward together.</div>
+      </div>
+    </blockquote>
+    <div><br></div>
+    <div>And you will not realize there is text here <span style="font-size:0.875rem"> </span></div>
+    <div><span style="font-size:0.875rem"><br></span></div>
+    <blockquote class="gmail_quote"
+      style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">
+      <div class="gmail-m_6323339324984540685main-style-6ddc6ddc57bd45f0d259">
+        <div></div>
+        <div>Now, you can invite guests to collaborate on your Front conversations or internal discussions, so no
+          one&#39;s left out. If they’ve got an email address (we bet they do <img alt="slightly_smiling_face"
+            src="https://assets.frontapp.com/emoji-data-1806/img-apple-64/1f642.png" width="20" height="20"
+            style="vertical-align: -4.55px;">), just add them. They’ll get instant access to the conversation where you
+          can all work together in one thread. <span style="background-color:rgb(255,255,0)">[or text here!!!!!]</span>
+        </div>
+        <div><br></div>
+        <div>Efficient collaboration with anyone you need? We think that’s how email should be. That’s why unlimited
+          conversation guests are available on all Front plans. You can keep everyone you work with on the same page,
+          right from your inbox.</div>
+        <div><br></div><br>
+        <div
+          class="gmail-m_6323339324984540685front-signature gmail-m_6323339324984540685fa-uid_ace7f9f45e61925e5cf8cd5df159dc62">
+          <div>—</div>
+          <div>Ailian Gan</div>
+          <div>Product @ <a href="https://frontapp.com/" rel="noopener noreferrer" target="_blank">Front</a></div>
+        </div>
+      </div><img src="https://app.frontapp.com/api/1/noauth/companies/front/seen/msg_2mci1nv/han_164nmf/0d125fdc.gif"
+        style="width: 1px; height: 1px;">
+    </blockquote>
+  </div>
+</div>

--- a/tests/fixtures/front/email_with_signature.html
+++ b/tests/fixtures/front/email_with_signature.html
@@ -1,0 +1,77 @@
+<html>
+
+ <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta content="text/html; charset=utf-8">
+</head>
+
+ <body>
+  <div dir="ltr">
+    <div class="mc-ip-hide">
+      <div style="color:#000000; font-size:12px; text-align:left; font-family:Helvetica,Arial,sans-serif">
+        <strong>
+          <p style="color:red">BLA</p>
+        </strong><br>
+      </div>
+      <hr>
+    </div>
+    BLA
+    <div><br>
+    </div>
+    <div>BLA!</div>
+  </div>
+  <br>
+  <div class="gmail_quote">
+    <div dir="ltr" class="gmail_attr">On Sun, Jul 28, 2019 at 2:53 PM  &lt;<a
+        href="test@frontapp.com">test@frontapp.com</a>&gt; wrote:<br>
+    </div>
+    <blockquote class="gmail_quote"
+      style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex">
+      <div>
+        <div class="gmail-m_-8033193872788031945main-style-c6fc1dcc6115a013830b">
+          <div>Hello B,</div>
+          <div><br>
+          </div>
+          <div>BLA!</div>
+      </div>
+    </blockquote>
+  </div>
+  <br clear="all">
+  <div><br>
+  </div>
+  -- <br>
+  <div dir="ltr" class="gmail_signature">
+    <div dir="ltr">
+      <div>
+        <div dir="ltr">
+          <div>
+            <div dir="ltr">
+              <div>
+                <div dir="ltr">
+                  <div>
+                    <div dir="ltr">
+                      <div dir="ltr">
+                        <div dir="ltr">Leo Vck<br>
+                        </div>
+                        <div dir="ltr">
+                          <div>
+                            <font size="2">Front</font>
+                          </div>
+                          </div>
+                          <div><br>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+ </html>

--- a/tests/fixtures/nylas/email_12_stripped.html
+++ b/tests/fixtures/nylas/email_12_stripped.html
@@ -1,20 +1,23 @@
 <html>
 
 <body>
-    <div> Hi,
-        <br/>
-        <p> You can list the keys for the bucket and call delete for each. Or if you put the keys (and kept track of them in your test) you can delete them one at a time (without incurring the cost of calling list first.) </p>
-        <p> Something like:
-            <br/> <pre>          String bucket = "my_bucket";         BucketResponse bucketResponse = riakClient.listBucket(bucket);         RiakBucketInfo bucketInfo = bucketResponse.getBucketInfo();                  for(String key : bucketInfo.getKeys()) {             riakClient.delete(bucket, key);         } </pre>            </p>
-        <p> would do it.
-            <br/> See also
-            <br/> http://wiki.basho.com/REST-API.html#Bucket-operations
-            <br/> which says
-            <br/> "At the moment there is no straightforward way to delete an entire Bucket. There is, however, an open ticket for the feature. To delete all the keys in a bucket, you’ll need to delete them all individually." </p>
-        <br/>
-        <br/>
-        <br/>
-        <br/> _______________________________________________ riak-users mailing list riak-users@lists.basho.com http://lists.basho.com/mailman/listinfo/riak-users_lists.basho.com </div>
+    <div> Hi,<br />
+        <blockquote class="foo"> On Tue, 2011-03-01 at 18:02 +0530, Abhishek Kona wrote: <div> > Hi folks <br /> >
+                <br /> > What is the best way to clear a Riak bucket of all key, values after <br /> > running a test?
+                <br /> > I am currently using the Java HTTP API. <br /> </div>
+        </blockquote>
+        <p> You can list the keys for the bucket and call delete for each. Or if you put the keys (and kept track of
+            them in your test) you can delete them one at a time (without incurring the cost of calling list first.)
+        </p>
+        <p> Something like: <br />
+            <pre>          String bucket = "my_bucket";         BucketResponse bucketResponse = riakClient.listBucket(bucket);         RiakBucketInfo bucketInfo = bucketResponse.getBucketInfo();                  for(String key : bucketInfo.getKeys()) {             riakClient.delete(bucket, key);         } </pre>
+        </p>
+        <p> would do it. <br /> See also <br /> http://wiki.basho.com/REST-API.html#Bucket-operations <br /> which says
+            <br /> "At the moment there is no straightforward way to delete an entire Bucket. There is, however, an open
+            ticket for the feature. To delete all the keys in a bucket, you’ll need to delete them all individually."
+        </p> <br /> <br /> <br /> <br /> _______________________________________________ riak-users mailing list
+        riak-users@lists.basho.com http://lists.basho.com/mailman/listinfo/riak-users_lists.basho.com
+    </div>
 </body>
 
 </html>

--- a/tests/fixtures/nylas/email_16_stripped.html
+++ b/tests/fixtures/nylas/email_16_stripped.html
@@ -1,1 +1,198 @@
-<html> <head> <meta http-equiv="Content-Type" content="text/html; charset=us-ascii"/> </head> <body>  </body> </html>
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+</head>
+
+<body>
+  <blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex;">
+    <div>Hi all,</div>
+    <div><br /> </div>
+    <div>Below is the sign up link for on-site massages tomorrow. The moussuse will arrive after lunch. Please sign up
+      for your time if you wish to participate :). </div>
+    <div><br /> </div>
+    <div>Makala </div> <br />
+    <style type="text/css">
+      /* Based on The MailChimp Reset INLINE: Yes. */
+      /* Client-specific Styles */
+      #outlook a {
+        padding: 0;
+      }
+
+      /* Force Outlook to provide a "view in browser" menu link. */
+      body {
+        width: 100% !important;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+        margin: 0;
+        padding: 0;
+      }
+
+      /* Prevent Webkit and Windows Mobile platforms from changing default font sizes.*/
+      .ExternalClass {
+        width: 100%;
+      }
+
+      /* Force Hotmail to display emails at full width */
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+
+      /* Forces Hotmail to display normal line spacing.  More on that: http://www.emailonacid.com/forum/viewthread/43/ */
+      #backgroundTable {
+        margin: 0;
+        padding: 0;
+        width: 100% !important;
+        line-height: 100% !important;
+      }
+
+      /* End reset */
+      /* Some sensible defaults for images             Bring inline: Yes. */
+      img {
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+
+      a img {
+        border: none;
+      }
+
+      .image_fix {
+        display: block;
+      }
+
+      /* Yahoo paragraph fix             Bring inline: Yes. */
+      p {
+        margin: 1em 0;
+      }
+
+      /* Hotmail header color reset             Bring inline: Yes. */
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        color: #8c8c8c !important;
+      }
+
+      h1 a,
+      h2 a,
+      h3 a,
+      h4 a,
+      h5 a,
+      h6 a {
+        color: blue !important;
+      }
+
+      h1 a:active,
+      h2 a:active,
+      h3 a:active,
+      h4 a:active,
+      h5 a:active,
+      h6 a:active {
+        color: red !important;
+        /* Preferably not the same color as the normal header link color.  There is limited support for psuedo classes in email clients, this was added just for good measure. */
+      }
+
+      h1 a:visited,
+      h2 a:visited,
+      h3 a:visited,
+      h4 a:visited,
+      h5 a:visited,
+      h6 a:visited {
+        color: purple !important;
+        /* Preferably not the same color as the normal header link color. There is limited support for psuedo classes in email clients, this was added just for good measure. */
+      }
+
+      /* Outlook 07, 10 Padding issue fix             Bring inline: No.*/
+      table td {
+        border-collapse: collapse;
+      }
+
+      /* Remove spacing around Outlook 07, 10 tables             Bring inline: Yes */
+      table {
+        border-collapse: collapse;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      /* Styling your links has become much simpler with the new Yahoo.  In fact, it falls in line with the main credo of styling in email and make sure to bring your styles inline.  Your link colors will be uniform across clients when brought inline.             Bring inline: Yes. */
+      a {
+        color: blue;
+      }
+
+      /***************************************************             ****************************************************             MOBILE TARGETING             ****************************************************             ***************************************************/
+      @media only screen and (max-device-width: 480px) {
+
+        /* Part one of controlling phone number linking for mobile. */
+        a[href^="tel"],
+        a[href^="sms"] {
+          text-decoration: none;
+          color: blue;
+          /* or whatever your want */
+          pointer-events: none;
+          cursor: default;
+        }
+
+        .mobile_link a[href^="tel"],
+        .mobile_link a[href^="sms"] {
+          text-decoration: default;
+          color: blue !important;
+          pointer-events: auto;
+          cursor: default;
+        }
+      }
+
+      /* More Specific Targeting */
+      @media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
+
+        /* You guessed it, ipad (tablets, smaller screens, etc) */
+        /* repeating for the ipad */
+        a[href^="tel"],
+        a[href^="sms"] {
+          text-decoration: none;
+          color: blue;
+          /* or whatever your want */
+          pointer-events: none;
+          cursor: default;
+        }
+
+        .mobile_link a[href^="tel"],
+        .mobile_link a[href^="sms"] {
+          text-decoration: default;
+          color: blue !important;
+          pointer-events: auto;
+          cursor: default;
+        }
+      }
+
+      @media only screen and (-webkit-min-device-pixel-ratio: 2) {
+        /* Put your iPhone 4g styles in here */
+      }
+
+      /* Android targeting */
+      @media only screen and (-webkit-device-pixel-ratio:.75) {
+        /* Put CSS for low density (ldpi) Android layouts in here */
+      }
+
+      @media only screen and (-webkit-device-pixel-ratio:1) {
+        /* Put CSS for medium density (mdpi) Android layouts in here */
+      }
+
+      @media only screen and (-webkit-device-pixel-ratio:1.5) {
+        /* Put CSS for high density (hdpi) Android layouts in here */
+      }
+
+      /* end Android targeting */
+    </style>
+  </blockquote>
+</body>
+
+</html>

--- a/tests/fixtures/nylas/email_1_stripped.html
+++ b/tests/fixtures/nylas/email_1_stripped.html
@@ -1,1 +1,17 @@
-<html> <head> <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/> </head> <body style="word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space;"> <div><span class="message_content"> <pre class="special_formatting"><font face="Calibri"><span style="font-size: 15px;">Hi Jeff,  Quick update on the event bugs: - I fixed the bug where events would be incorrectly marked as read-only. - We expose RRULEs as valid JSON now.   We're currently testing the fixes, they should ship early next week.  Concerning timezones, an event should always be associated with a timezone. Having a NULL value instead is a bug on our end. I will be working on fixing this on Monday and will let you know when it's fixed.  Thanks for your detailed bug reports,</span></font></pre> <pre class="special_formatting"><font face="Calibri"><span style="font-size: 15px;"> Karim</span></font></pre> <pre class="special_formatting" style="color: rgb(0, 0, 0); font-family: Calibri, sans-serif; font-size: 14px;"><span style="font-family: Calibri; font-size: 11pt; font-weight: bold;">From: </span><span style="font-family: Calibri; font-size: 11pt;"> Kavya Joshi &lt;</span><a href="mailto:kavya@nylas.com" style="font-family: Calibri; font-size: 11pt;">kavya@nylas.com</a><span style="font-family: Calibri; font-size: 11pt;">></span></pre> </span></div> <span id="OLK_SRC_BODY_SECTION" style="color: rgb(0, 0, 0); font-family: Calibri, sans-serif; font-size: 14px;"> </span> </body> </html>
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+</head>
+
+<body style="word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space;">
+  <div><span class="message_content">
+      <pre
+        class="special_formatting"><font face="Calibri"><span style="font-size: 15px;">Hi Jeff,  Quick update on the event bugs: - I fixed the bug where events would be incorrectly marked as read-only. - We expose RRULEs as valid JSON now.   We're currently testing the fixes, they should ship early next week.  Concerning timezones, an event should always be associated with a timezone. Having a NULL value instead is a bug on our end. I will be working on fixing this on Monday and will let you know when it's fixed.  Thanks for your detailed bug reports,</span></font></pre>
+      <pre class="special_formatting"><font face="Calibri"><span style="font-size: 15px;"> Karim</span></font></pre>
+      <pre class="special_formatting"
+        style="color: rgb(0, 0, 0); font-family: Calibri, sans-serif; font-size: 14px;"><span style="font-family: Calibri; font-size: 11pt; font-weight: bold;">From: </span><span style="font-family: Calibri; font-size: 11pt;"> Kavya Joshi &lt;</span><a href="mailto:kavya@nylas.com" style="font-family: Calibri; font-size: 11pt;">kavya@nylas.com</a><span style="font-family: Calibri; font-size: 11pt;">></span></pre>
+    </span></div>
+</body>
+
+</html>

--- a/tests/fixtures/nylas/email_5_stripped.html
+++ b/tests/fixtures/nylas/email_5_stripped.html
@@ -1,10 +1,23 @@
 <html>
+
 <head></head>
 
 <body>
     <div id="inbox-html-wrapper" class="show-quoted-text">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <div dir="ltr"></div></div>
+        <div dir="ltr">
+            <div class="gmail_quote">
+                <div>Just an update on this guys, we had three other customers login this morning and it seems that
+                    their accounts are also listed as: "Sync not running" but some of their messages have been synced.
+                    Emails are below:<br /><br /><a href="mailto:drew@a.com">drew@a.com</a> (which is somehow listed
+                    twice)<br /><a href="mailto:s.k@g.com">s.k@g.com</a><br /><a
+                        href="mailto:oprokhorenko@splunk.com">oprokhorenko@splunk.com</a></div>
+                <div><br /></div>
+                <div>-Andrew</div>
+                <div></div>
+            </div>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -317,8 +317,6 @@ describe("Html Quotations", function () {
                 return nextFile(err2);
 
               const replyHtml = quotations.extractFromHtml(html).body;
-              console.log(file);
-              console.log(replyHtml);
               assert.equal(
                 removeWhitespace(htmlStripped),
                 removeWhitespace(replyHtml));

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -9,288 +9,288 @@ const quotations = require("../bin/Talon").quotations;
 
 describe("Html Quotations", function () {
 
-  describe("Extract html", function () {
+  // describe("Extract html", function () {
 
-    it("should find reply with the quotation splitter inside a blockquote.", function () {
-      const messageBody = "Reply\n" +
-        "<blockquote>\n\n" +
-        "<div>\n" +
-        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-        "</div>\n\n" +
-        "<div>\n" +
-        "Test\n" +
-        "</div>\n\n" +
-        "</blockquote>";
+  //   it("should find reply with the quotation splitter inside a blockquote.", function () {
+  //     const messageBody = "Reply\n" +
+  //       "<blockquote>\n\n" +
+  //       "<div>\n" +
+  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+  //       "</div>\n\n" +
+  //       "<div>\n" +
+  //       "Test\n" +
+  //       "</div>\n\n" +
+  //       "</blockquote>";
 
-      const reply = "<html><body>Reply</body></html>";
+  //     const reply = "<html><body>Reply</body></html>";
 
-      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should find the reply with the quotation splitter outside the blockquote.", function () {
-      const messageBody = "Reply\n\n" +
-        "<div>\n" +
-        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-        "</div>\n\n" +
-        "<blockquote>\n" +
-        "<div>\n" +
-        "Test\n" +
-        "</div>\n"
-        "</blockquote>";
+  //   it("should find the reply with the quotation splitter outside the blockquote.", function () {
+  //     const messageBody = "Reply\n\n" +
+  //       "<div>\n" +
+  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+  //       "</div>\n\n" +
+  //       "<blockquote>\n" +
+  //       "<div>\n" +
+  //       "Test\n" +
+  //       "</div>\n"
+  //       "</blockquote>";
 
-      const reply = "<html><body>Reply</body></html>";
+  //     const reply = "<html><body>Reply</body></html>";
 
-      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should find the reply with a regular blockquote before the splitter.", function () {
-      const messageBody = "Reply\n" +
-        "<blockquote>Regular</blockquote>\n\n" +
-        "<div>\n" +
-        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-        "</div>\n\n" +
-        "<blockquote>\n" +
-        "<div>\n" +
-        "<blockquote>Nested</blockquote>\n" +
-        "</div>\n"
-        "</blockquote>";
+  //   it("should find the reply with a regular blockquote before the splitter.", function () {
+  //     const messageBody = "Reply\n" +
+  //       "<blockquote>Regular</blockquote>\n\n" +
+  //       "<div>\n" +
+  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+  //       "</div>\n\n" +
+  //       "<blockquote>\n" +
+  //       "<div>\n" +
+  //       "<blockquote>Nested</blockquote>\n" +
+  //       "</div>\n"
+  //       "</blockquote>";
 
-      const reply = "<html><body>Reply<blockquote>Regular</blockquote></body></html>";
+  //     const reply = "<html><body>Reply<blockquote>Regular</blockquote></body></html>";
 
-      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should find the reply with no blockquotes.", function () {
-      const messageBody = "\n<html>\n" +
-        "<body>\n" +
-        "Reply\n\n" +
-        "<div>\n" +
-        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-        "</div>\n\n" +
-        "<div>\n" +
-        "Test\n" +
-        "</div>\n" +
-        "</body>\n" +
-        "</html>\n";
+  //   it("should find the reply with no blockquotes.", function () {
+  //     const messageBody = "\n<html>\n" +
+  //       "<body>\n" +
+  //       "Reply\n\n" +
+  //       "<div>\n" +
+  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+  //       "</div>\n\n" +
+  //       "<div>\n" +
+  //       "Test\n" +
+  //       "</div>\n" +
+  //       "</body>\n" +
+  //       "</html>\n";
 
-      const reply = "<html>" +
-        "<body>" +
-        "Reply\n\n" +
-        "</body></html>";
+  //     const reply = "<html>" +
+  //       "<body>" +
+  //       "Reply\n\n" +
+  //       "</body></html>";
 
-      assert.equal(
-        removeWhitespace(reply),
-        removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(
+  //       removeWhitespace(reply),
+  //       removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should find an empty reply from an empty body.", function () {
-      assert.equal("", quotations.extractFromHtml("").body);
-    });
+  //   it("should find an empty reply from an empty body.", function () {
+  //     assert.equal("", quotations.extractFromHtml("").body);
+  //   });
 
-    it("should validate that we always output valid HTML.", function () {
-      const messageBody = "Reply\n" +
-        "<div>\n" +
-        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n\n" +
-        "<blockquote>\n" +
-        "<div>\n" +
-        "Test\n" +
-        "</div>\n" +
-        "</blockquote>\n" +
-        "</div>\n\n" +
-        "<div/>\n";
+  //   it("should validate that we always output valid HTML.", function () {
+  //     const messageBody = "Reply\n" +
+  //       "<div>\n" +
+  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n\n" +
+  //       "<blockquote>\n" +
+  //       "<div>\n" +
+  //       "Test\n" +
+  //       "</div>\n" +
+  //       "</blockquote>\n" +
+  //       "</div>\n\n" +
+  //       "<div/>\n";
 
-      const result = quotations.extractFromHtml(messageBody).body;
-      assert.isAtLeast(result.indexOf("<html>"), 0);
-      assert.isAtLeast(result.indexOf("</html>"), 0);
-    });
+  //     const result = quotations.extractFromHtml(messageBody).body;
+  //     assert.isAtLeast(result.indexOf("<html>"), 0);
+  //     assert.isAtLeast(result.indexOf("</html>"), 0);
+  //   });
 
-    it("should strip Gmail quote.", function () {
-       const messageBody = `Reply
-        <div class="gmail_quote">
-          <div class="gmail_quote">
-            On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:
-            <div>
-              Test
-            </div>
-          </div>
-        </div>`;
+  //   it("should strip Gmail quote.", function () {
+  //      const messageBody = `Reply
+  //       <div class="gmail_quote">
+  //         <div class="gmail_quote">
+  //           On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:
+  //           <div>
+  //             Test
+  //           </div>
+  //         </div>
+  //       </div>`;
 
-      const reply = "<html><body>Reply         </body></html>";
+  //     const reply = "<html><body>Reply         </body></html>";
 
-      assert.equal(reply, quotations.extractFromHtml(messageBody).body);
-    });
+  //     assert.equal(reply, quotations.extractFromHtml(messageBody).body);
+  //   });
 
-    it("should strip Gmail quote compact.", function () {
-       const messageBody =  "Reply" +
-        "<div class=\"gmail_quote\">" +
-        "<div class=\"gmail_quote\">On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:" +
-        "<div>Test</div>" +
-        "</div>" +
-        "</div>";
+  //   it("should strip Gmail quote compact.", function () {
+  //      const messageBody =  "Reply" +
+  //       "<div class=\"gmail_quote\">" +
+  //       "<div class=\"gmail_quote\">On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:" +
+  //       "<div>Test</div>" +
+  //       "</div>" +
+  //       "</div>";
 
-      const reply = "<html><body>Reply</body></html>";
+  //     const reply = "<html><body>Reply</body></html>";
 
-      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("shouldn't strip Gmail quote in blockquote.", function () {
-       const messageBody =  "Message" +
-        "<blockquote class=\"gmail_quote\">" +
-        "<div class=\"gmail_default\">" +
-        "My name is William Shakespeare." +
-        "<br/>" +
-        "</div>" +
-        "</blockquote>";
+  //   it("shouldn't strip Gmail quote in blockquote.", function () {
+  //      const messageBody =  "Message" +
+  //       "<blockquote class=\"gmail_quote\">" +
+  //       "<div class=\"gmail_default\">" +
+  //       "My name is William Shakespeare." +
+  //       "<br/>" +
+  //       "</div>" +
+  //       "</blockquote>";
 
-      assert.equal(
-        removeWhitespace("<html><body>Message</body></html>"),
-        removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(
+  //       removeWhitespace("<html><body>Message</body></html>"),
+  //       removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should detect reply with disclaimer after quote.", function () {
-       const messageBody = "\n<html>\n" +
-        "<body>\n" +
-        "<div>\n" +
-        "<div>\n" +
-        "message\n" +
-        "</div>\n" +
-        "<blockquote>\n" +
-        "Quote\n" +
-        "</blockquote>\n" +
-        "</div>\n" +
-        "<div>\n" +
-        "disclaimer\n" +
-        "</div>\n" +
-        "</body>\n" +
-        "</html>\n";
+  //   it("should detect reply with disclaimer after quote.", function () {
+  //      const messageBody = "\n<html>\n" +
+  //       "<body>\n" +
+  //       "<div>\n" +
+  //       "<div>\n" +
+  //       "message\n" +
+  //       "</div>\n" +
+  //       "<blockquote>\n" +
+  //       "Quote\n" +
+  //       "</blockquote>\n" +
+  //       "</div>\n" +
+  //       "<div>\n" +
+  //       "disclaimer\n" +
+  //       "</div>\n" +
+  //       "</body>\n" +
+  //       "</html>\n";
 
-      const reply = "\n<html>\n" +
-        "<body>\n" +
-        "<div>\n" +
-        "<div>\n" +
-        "message\n" +
-        "</div>\n" +
-        "</div>\n" +
-        "<div>\n" +
-        "disclaimer\n" +
-        "</div>\n" +
-        "</body>\n" +
-        "</html>\n";
+  //     const reply = "\n<html>\n" +
+  //       "<body>\n" +
+  //       "<div>\n" +
+  //       "<div>\n" +
+  //       "message\n" +
+  //       "</div>\n" +
+  //       "</div>\n" +
+  //       "<div>\n" +
+  //       "disclaimer\n" +
+  //       "</div>\n" +
+  //       "</body>\n" +
+  //       "</html>\n";
 
-      assert.equal(
-        removeWhitespace(reply),
-        removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(
+  //       removeWhitespace(reply),
+  //       removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should detect reply with \"date\" block splitter.", function () {
-      const messageBody = "\n<div>" +
-        "message<br>\n" +
-        "<div>\n" +
-        "<hr>\n" +
-        "Date: Fri, 23 Mar 2012 12:35:31 -0600<br>\n" +
-        "To: <a href=\"mailto:bob@example.com\">bob@example.com</a><br>\n" +
-        "From: <a href=\"mailto:rob@example.com\">rob@example.com</a><br>\n" +
-        "Subject: You Have New Mail From Mary!<br><br>\n\n" +
-        "text\n" +
-        "</div>\n" +
-        "</div>\n";
+  //   it("should detect reply with \"date\" block splitter.", function () {
+  //     const messageBody = "\n<div>" +
+  //       "message<br>\n" +
+  //       "<div>\n" +
+  //       "<hr>\n" +
+  //       "Date: Fri, 23 Mar 2012 12:35:31 -0600<br>\n" +
+  //       "To: <a href=\"mailto:bob@example.com\">bob@example.com</a><br>\n" +
+  //       "From: <a href=\"mailto:rob@example.com\">rob@example.com</a><br>\n" +
+  //       "Subject: You Have New Mail From Mary!<br><br>\n\n" +
+  //       "text\n" +
+  //       "</div>\n" +
+  //       "</div>\n";
 
-      const reply = "<html><body><div>message<br/></div></body></html>";
+  //     const reply = "<html><body><div>message<br/></div></body></html>";
 
 
-      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should detect reply with \"from\" block splitter.", function () {
-      const messageBody = `<div>
-        message<br>
-        <div>
-        <hr>
-        From: <a href="mailto:bob@example.com">bob@example.com</a><br>
-        Date: Fri, 23 Mar 2012 12:35:31 -0600<br>
-        To: <a href="mailto:rob@example.com">rob@example.com</a><br>
-        Subject: You Have New Mail From Mary!<br><br>
+  //   it("should detect reply with \"from\" block splitter.", function () {
+  //     const messageBody = `<div>
+  //       message<br>
+  //       <div>
+  //       <hr>
+  //       From: <a href="mailto:bob@example.com">bob@example.com</a><br>
+  //       Date: Fri, 23 Mar 2012 12:35:31 -0600<br>
+  //       To: <a href="mailto:rob@example.com">rob@example.com</a><br>
+  //       Subject: You Have New Mail From Mary!<br><br>
 
-        text
-        </div></div>`;
+  //       text
+  //       </div></div>`;
 
-      const reply = "<html><body><div>message<br/></div></body></html>";
+  //     const reply = "<html><body><div>message<br/></div></body></html>";
 
-      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
+  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
 
-    it("should detect reply with content in same element as \"from\" block splitter.", function () {
-      const messageBody = `
-        <body>
-          <div>
+  //   it("should detect reply with content in same element as \"from\" block splitter.", function () {
+  //     const messageBody = `
+  //       <body>
+  //         <div>
 
-            Blah<br><br>
+  //           Blah<br><br>
 
-            <hr>Date: Tue, 22 May 2012 18:29:16 -0600<br>
-            To: xx@hotmail.ca<br>
-            From: quickemail@ashleymadison.com<br>
-            Subject: You Have New Mail From x!<br><br>
+  //           <hr>Date: Tue, 22 May 2012 18:29:16 -0600<br>
+  //           To: xx@hotmail.ca<br>
+  //           From: quickemail@ashleymadison.com<br>
+  //           Subject: You Have New Mail From x!<br><br>
 
-          </div>
-        </body>`;
+  //         </div>
+  //       </body>`;
 
-      const reply = "<html><body><div>Blah<br/><br/></div></body></html>";
-      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-    });
-  });
+  //     const reply = "<html><body><div>Blah<br/><br/></div></body></html>";
+  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+  //   });
+  // });
 
-  describe("Talon fixtures", function () {
+  // describe("Talon fixtures", function () {
 
-    it("should find reply in OLK src body section.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "talon", "OLK_SRC_BODY_SECTION.html"), "utf-8", function (err, html) {
-        if (err)
-          return done(err);
+  //   it("should find reply in OLK src body section.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "talon", "OLK_SRC_BODY_SECTION.html"), "utf-8", function (err, html) {
+  //       if (err)
+  //         return done(err);
 
-        const reply = "<html><body><div>Reply</div></body></html>";
-        assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
-        done();
-      });
-    });
+  //       const reply = "<html><body><div>Reply</div></body></html>";
+  //       assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
+  //       done();
+  //     });
+  //   });
 
-    it("should find reply with <hr> separator.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "talon", "reply-separated-by-hr.html"), "utf-8", function (err, html) {
-        if (err)
-          return done(err);
+  //   it("should find reply with <hr> separator.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "talon", "reply-separated-by-hr.html"), "utf-8", function (err, html) {
+  //       if (err)
+  //         return done(err);
 
-        const reply = "<html><body><div>Hi<div>there</div><div>Bob<hr/><br/></div></div></body></html>";
-        assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
-        done();
-      });
-    });
+  //       const reply = "<html><body><div>Hi<div>there</div><div>Bob<hr/><br/></div></div></body></html>";
+  //       assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
+  //       done();
+  //     });
+  //   });
 
-    it("should use fixtures to test ExtractFromHtml method.", function (done) {
-      // List the fixtures.
-      const htmlRepliesPath = path.join("tests", "fixtures", "talon", "html_replies");
-      return fs.readdir(htmlRepliesPath, (err, files) => {
-        if (err)
-          return done(err);
+  //   it("should use fixtures to test ExtractFromHtml method.", function (done) {
+  //     // List the fixtures.
+  //     const htmlRepliesPath = path.join("tests", "fixtures", "talon", "html_replies");
+  //     return fs.readdir(htmlRepliesPath, (err, files) => {
+  //       if (err)
+  //         return done(err);
 
-        // Iterate on the files we found.
-        return async.eachSeries(files, (file, nextFile) => {
+  //       // Iterate on the files we found.
+  //       return async.eachSeries(files, (file, nextFile) => {
 
-          // Read the file.
-          return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
-            if (err)
-              return nextFile(err);
+  //         // Read the file.
+  //         return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
+  //           if (err)
+  //             return nextFile(err);
 
-            const replyHtml = quotations.extractFromHtml(html).body;
-            const replyPlain = utils.htmlToText(replyHtml);
+  //           const replyHtml = quotations.extractFromHtml(html).body;
+  //           const replyPlain = utils.htmlToText(replyHtml);
 
-            assert.equal(
-              removeWhitespace("Hi. I am fine.\n\nThanks,\nAlex"),
-              removeWhitespace(replyPlain));
+  //           assert.equal(
+  //             removeWhitespace("Hi. I am fine.\n\nThanks,\nAlex"),
+  //             removeWhitespace(replyPlain));
 
-            return nextFile();
-          });
-        }, done);
-      });
-    });
-  });
+  //           return nextFile();
+  //         });
+  //       }, done);
+  //     });
+  //   });
+  // });
 
   describe("Nylas fixtures", function () {
 
@@ -317,6 +317,8 @@ describe("Html Quotations", function () {
                 return nextFile(err2);
 
               const replyHtml = quotations.extractFromHtml(html).body;
+              console.log(file);
+              console.log(replyHtml);
               assert.equal(
                 removeWhitespace(htmlStripped),
                 removeWhitespace(replyHtml));
@@ -329,107 +331,131 @@ describe("Html Quotations", function () {
     });
   });
 
-  describe("Front fixtures", function () {
+  // describe("Front fixtures", function () {
 
-    it("should correctly render Outlook comments.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_conditional_comments.html"), "utf-8", (err, html) => {
-        if (err)
-          return done(err);
+  //   it("should correctly render Outlook comments.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_conditional_comments.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
 
-        // Extract the quote.
-        var replyHtml = quotations.extractFromHtml(html).body;
+  //       // Extract the quote.
+  //       var replyHtml = quotations.extractFromHtml(html).body;
 
-        // Make sure it doesn't contain the incriminating string.
-        assert.notInclude(replyHtml, "<![if !supportLists]>", "The reply does not keep Word comments");
-        assert.notInclude(replyHtml, "&lt;![if !supportLists]>", "The reply does not transform Word comments");
-        done();
-      });
-    });
+  //       // Make sure it doesn't contain the incriminating string.
+  //       assert.notInclude(replyHtml, "<![if !supportLists]>", "The reply does not keep Word comments");
+  //       assert.notInclude(replyHtml, "&lt;![if !supportLists]>", "The reply does not transform Word comments");
+  //       done();
+  //     });
+  //   });
 
-    it("should correctly render emails with From: not followed by @ or Sent.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_from.html"), "utf-8", (err, html) => {
-        if (err)
-          return done(err);
+  //   it("should correctly render emails with From: not followed by @ or Sent.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_from.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
 
-        // Extract the quote.
-        var replyHtml = quotations.extractFromHtml(html).body;
+  //       // Extract the quote.
+  //       var replyHtml = quotations.extractFromHtml(html).body;
 
-        assert.include(replyHtml, "29 missing", "The reply does not cut From:");
-        done();
-      });
-    });
+  //       assert.include(replyHtml, "29 missing", "The reply does not cut From:");
+  //       done();
+  //     });
+  //   });
 
-    it("should correctly detect tables.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_table.html"), "utf-8", (err, html) => {
-        if (err)
-          return done(err);
+  //   it("should correctly detect tables.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_table.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
 
-        // Extract the quote.
-        var replyHtml = quotations.extractFromHtml(html).body;
+  //       // Extract the quote.
+  //       var replyHtml = quotations.extractFromHtml(html).body;
 
-        assert.equal(
-          removeWhitespace(utils.htmlToText(replyHtml)),
-          removeWhitespace(utils.htmlToText(html)));
-        done();
-      });
-    });
+  //       assert.equal(
+  //         removeWhitespace(utils.htmlToText(replyHtml)),
+  //         removeWhitespace(utils.htmlToText(html)));
+  //       done();
+  //     });
+  //   });
 
-    it("should not crash when no XmlDom document is found.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_no_doc.html"), "utf-8", (err, html) => {
-        if (err)
-          return done(err);
+  //   it("should not crash when no XmlDom document is found.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_no_doc.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
 
-        // Extract the quote.
-        quotations.extractFromHtml(html).body;
-        done();
-      });
-    });
+  //       // Extract the quote.
+  //       quotations.extractFromHtml(html).body;
+  //       done();
+  //     });
+  //   });
 
-    it("should correctly parse quotation.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "front", "email_error_quote.html"), "utf-8", (err, html) => {
-        if (err)
-          return done(err);
+  //   it("should correctly parse quotation.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_error_quote.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
 
-        // Extract the quote.
-        const replyHtml = quotations.extractFromHtml(html).body;
-        assert.notInclude(replyHtml, "Bla");
-        return done();
-      });
-    });
+  //       // Extract the quote.
+  //       const replyHtml = quotations.extractFromHtml(html).body;
+  //       assert.notInclude(replyHtml, "Bla");
+  //       return done();
+  //     });
+  //   });
 
-    it("should correctly parse email with \n.", function (done) {
-      return fs.readFile(path.join("tests", "fixtures", "front", "email_error_line_break.html"), "utf-8", (err, html) => {
-        if (err)
-          return done(err);
+  //   it("should correctly parse email with \n.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_error_line_break.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
 
-        // Extract the quote.
-        const replyHtml = quotations.extractFromHtml(html).body;
-        assert.notInclude(replyHtml, "Hello from quote");
-        return done();
-      });
-    });
+  //       // Extract the quote.
+  //       const replyHtml = quotations.extractFromHtml(html).body;
+  //       assert.notInclude(replyHtml, "Hello from quote");
+  //       return done();
+  //     });
+  //   });
 
-    it("should test emails that used to crash extractFromHtml.", function (done) {
-      // List the fixtures.
-      const htmlRepliesPath = path.join("tests", "fixtures", "front", "crashers");
-      return fs.readdir(htmlRepliesPath, (err, files) => {
-        if (err)
-          return done(err);
+  //   it("should correctly parse email with gmail quote in reply.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_quote.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
 
-        // Iterate on the files we found.
-        return async.eachSeries(files, (file, nextFile) => {
-          // Read the file.
-          return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
-            if (err)
-              return nextFile(err);
+  //        // Extract the quote.
+  //       const replyHtml = quotations.extractFromHtml(html).body;
+  //       assert.include(replyHtml, "Too often, how we work with people outside");
+  //       return done();
+  //     });
+  //   });
 
-            quotations.extractFromHtml(html);
-            return nextFile();
-          });
-        }, done);
-      });
-    });
-  });
+  //      it("should correctly parse email with signature in reply.", function (done) {
+  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_signature.html"), "utf-8", (err, html) => {
+  //       if (err)
+  //         return done(err);
+
+  //        // Extract the quote.
+  //       const replyHtml = quotations.extractFromHtml(html).body;
+  //       assert.notInclude(replyHtml, "Leo Vck");
+  //       return done();
+  //     });
+  //   });
+
+  //   it("should test emails that used to crash extractFromHtml.", function (done) {
+  //     // List the fixtures.
+  //     const htmlRepliesPath = path.join("tests", "fixtures", "front", "crashers");
+  //     return fs.readdir(htmlRepliesPath, (err, files) => {
+  //       if (err)
+  //         return done(err);
+
+  //       // Iterate on the files we found.
+  //       return async.eachSeries(files, (file, nextFile) => {
+  //         // Read the file.
+  //         return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
+  //           if (err)
+  //             return nextFile(err);
+
+  //           quotations.extractFromHtml(html);
+  //           return nextFile();
+  //         });
+  //       }, done);
+  //     });
+  //   });
+  // });
 
 });
 

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -9,288 +9,288 @@ const quotations = require("../bin/Talon").quotations;
 
 describe("Html Quotations", function () {
 
-  // describe("Extract html", function () {
+  describe("Extract html", function () {
 
-  //   it("should find reply with the quotation splitter inside a blockquote.", function () {
-  //     const messageBody = "Reply\n" +
-  //       "<blockquote>\n\n" +
-  //       "<div>\n" +
-  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-  //       "</div>\n\n" +
-  //       "<div>\n" +
-  //       "Test\n" +
-  //       "</div>\n\n" +
-  //       "</blockquote>";
+    it("should find reply with the quotation splitter inside a blockquote.", function () {
+      const messageBody = "Reply\n" +
+        "<blockquote>\n\n" +
+        "<div>\n" +
+        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+        "</div>\n\n" +
+        "<div>\n" +
+        "Test\n" +
+        "</div>\n\n" +
+        "</blockquote>";
 
-  //     const reply = "<html><body>Reply</body></html>";
+      const reply = "<html><body>Reply</body></html>";
 
-  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should find the reply with the quotation splitter outside the blockquote.", function () {
-  //     const messageBody = "Reply\n\n" +
-  //       "<div>\n" +
-  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-  //       "</div>\n\n" +
-  //       "<blockquote>\n" +
-  //       "<div>\n" +
-  //       "Test\n" +
-  //       "</div>\n"
-  //       "</blockquote>";
+    it("should find the reply with the quotation splitter outside the blockquote.", function () {
+      const messageBody = "Reply\n\n" +
+        "<div>\n" +
+        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+        "</div>\n\n" +
+        "<blockquote>\n" +
+        "<div>\n" +
+        "Test\n" +
+        "</div>\n"
+        "</blockquote>";
 
-  //     const reply = "<html><body>Reply</body></html>";
+      const reply = "<html><body>Reply</body></html>";
 
-  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should find the reply with a regular blockquote before the splitter.", function () {
-  //     const messageBody = "Reply\n" +
-  //       "<blockquote>Regular</blockquote>\n\n" +
-  //       "<div>\n" +
-  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-  //       "</div>\n\n" +
-  //       "<blockquote>\n" +
-  //       "<div>\n" +
-  //       "<blockquote>Nested</blockquote>\n" +
-  //       "</div>\n"
-  //       "</blockquote>";
+    it("should find the reply with a regular blockquote before the splitter.", function () {
+      const messageBody = "Reply\n" +
+        "<blockquote>Regular</blockquote>\n\n" +
+        "<div>\n" +
+        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+        "</div>\n\n" +
+        "<blockquote>\n" +
+        "<div>\n" +
+        "<blockquote>Nested</blockquote>\n" +
+        "</div>\n"
+        "</blockquote>";
 
-  //     const reply = "<html><body>Reply<blockquote>Regular</blockquote></body></html>";
+      const reply = "<html><body>Reply<blockquote>Regular</blockquote></body></html>";
 
-  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should find the reply with no blockquotes.", function () {
-  //     const messageBody = "\n<html>\n" +
-  //       "<body>\n" +
-  //       "Reply\n\n" +
-  //       "<div>\n" +
-  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
-  //       "</div>\n\n" +
-  //       "<div>\n" +
-  //       "Test\n" +
-  //       "</div>\n" +
-  //       "</body>\n" +
-  //       "</html>\n";
+    it("should find the reply with no blockquotes.", function () {
+      const messageBody = "\n<html>\n" +
+        "<body>\n" +
+        "Reply\n\n" +
+        "<div>\n" +
+        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n" +
+        "</div>\n\n" +
+        "<div>\n" +
+        "Test\n" +
+        "</div>\n" +
+        "</body>\n" +
+        "</html>\n";
 
-  //     const reply = "<html>" +
-  //       "<body>" +
-  //       "Reply\n\n" +
-  //       "</body></html>";
+      const reply = "<html>" +
+        "<body>" +
+        "Reply\n\n" +
+        "</body></html>";
 
-  //     assert.equal(
-  //       removeWhitespace(reply),
-  //       removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(
+        removeWhitespace(reply),
+        removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should find an empty reply from an empty body.", function () {
-  //     assert.equal("", quotations.extractFromHtml("").body);
-  //   });
+    it("should find an empty reply from an empty body.", function () {
+      assert.equal("", quotations.extractFromHtml("").body);
+    });
 
-  //   it("should validate that we always output valid HTML.", function () {
-  //     const messageBody = "Reply\n" +
-  //       "<div>\n" +
-  //       "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n\n" +
-  //       "<blockquote>\n" +
-  //       "<div>\n" +
-  //       "Test\n" +
-  //       "</div>\n" +
-  //       "</blockquote>\n" +
-  //       "</div>\n\n" +
-  //       "<div/>\n";
+    it("should validate that we always output valid HTML.", function () {
+      const messageBody = "Reply\n" +
+        "<div>\n" +
+        "On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:\n\n" +
+        "<blockquote>\n" +
+        "<div>\n" +
+        "Test\n" +
+        "</div>\n" +
+        "</blockquote>\n" +
+        "</div>\n\n" +
+        "<div/>\n";
 
-  //     const result = quotations.extractFromHtml(messageBody).body;
-  //     assert.isAtLeast(result.indexOf("<html>"), 0);
-  //     assert.isAtLeast(result.indexOf("</html>"), 0);
-  //   });
+      const result = quotations.extractFromHtml(messageBody).body;
+      assert.isAtLeast(result.indexOf("<html>"), 0);
+      assert.isAtLeast(result.indexOf("</html>"), 0);
+    });
 
-  //   it("should strip Gmail quote.", function () {
-  //      const messageBody = `Reply
-  //       <div class="gmail_quote">
-  //         <div class="gmail_quote">
-  //           On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:
-  //           <div>
-  //             Test
-  //           </div>
-  //         </div>
-  //       </div>`;
+    it("should strip Gmail quote.", function () {
+       const messageBody = `Reply
+        <div class="gmail_quote">
+          <div class="gmail_quote">
+            On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:
+            <div>
+              Test
+            </div>
+          </div>
+        </div>`;
 
-  //     const reply = "<html><body>Reply         </body></html>";
+      const reply = "<html><body>Reply         </body></html>";
 
-  //     assert.equal(reply, quotations.extractFromHtml(messageBody).body);
-  //   });
+      assert.equal(reply, quotations.extractFromHtml(messageBody).body);
+    });
 
-  //   it("should strip Gmail quote compact.", function () {
-  //      const messageBody =  "Reply" +
-  //       "<div class=\"gmail_quote\">" +
-  //       "<div class=\"gmail_quote\">On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:" +
-  //       "<div>Test</div>" +
-  //       "</div>" +
-  //       "</div>";
+    it("should strip Gmail quote compact.", function () {
+       const messageBody =  "Reply" +
+        "<div class=\"gmail_quote\">" +
+        "<div class=\"gmail_quote\">On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:" +
+        "<div>Test</div>" +
+        "</div>" +
+        "</div>";
 
-  //     const reply = "<html><body>Reply</body></html>";
+      const reply = "<html><body>Reply</body></html>";
 
-  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("shouldn't strip Gmail quote in blockquote.", function () {
-  //      const messageBody =  "Message" +
-  //       "<blockquote class=\"gmail_quote\">" +
-  //       "<div class=\"gmail_default\">" +
-  //       "My name is William Shakespeare." +
-  //       "<br/>" +
-  //       "</div>" +
-  //       "</blockquote>";
+    it("shouldn't strip Gmail quote in blockquote.", function () {
+       const messageBody =  "Message" +
+        "<blockquote class=\"gmail_quote\">" +
+        "<div class=\"gmail_default\">" +
+        "My name is William Shakespeare." +
+        "<br/>" +
+        "</div>" +
+        "</blockquote>";
 
-  //     assert.equal(
-  //       removeWhitespace("<html><body>Message</body></html>"),
-  //       removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(
+        removeWhitespace("<html><body>Message</body></html>"),
+        removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should detect reply with disclaimer after quote.", function () {
-  //      const messageBody = "\n<html>\n" +
-  //       "<body>\n" +
-  //       "<div>\n" +
-  //       "<div>\n" +
-  //       "message\n" +
-  //       "</div>\n" +
-  //       "<blockquote>\n" +
-  //       "Quote\n" +
-  //       "</blockquote>\n" +
-  //       "</div>\n" +
-  //       "<div>\n" +
-  //       "disclaimer\n" +
-  //       "</div>\n" +
-  //       "</body>\n" +
-  //       "</html>\n";
+    it("should detect reply with disclaimer after quote.", function () {
+       const messageBody = "\n<html>\n" +
+        "<body>\n" +
+        "<div>\n" +
+        "<div>\n" +
+        "message\n" +
+        "</div>\n" +
+        "<blockquote>\n" +
+        "Quote\n" +
+        "</blockquote>\n" +
+        "</div>\n" +
+        "<div>\n" +
+        "disclaimer\n" +
+        "</div>\n" +
+        "</body>\n" +
+        "</html>\n";
 
-  //     const reply = "\n<html>\n" +
-  //       "<body>\n" +
-  //       "<div>\n" +
-  //       "<div>\n" +
-  //       "message\n" +
-  //       "</div>\n" +
-  //       "</div>\n" +
-  //       "<div>\n" +
-  //       "disclaimer\n" +
-  //       "</div>\n" +
-  //       "</body>\n" +
-  //       "</html>\n";
+      const reply = "\n<html>\n" +
+        "<body>\n" +
+        "<div>\n" +
+        "<div>\n" +
+        "message\n" +
+        "</div>\n" +
+        "</div>\n" +
+        "<div>\n" +
+        "disclaimer\n" +
+        "</div>\n" +
+        "</body>\n" +
+        "</html>\n";
 
-  //     assert.equal(
-  //       removeWhitespace(reply),
-  //       removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(
+        removeWhitespace(reply),
+        removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should detect reply with \"date\" block splitter.", function () {
-  //     const messageBody = "\n<div>" +
-  //       "message<br>\n" +
-  //       "<div>\n" +
-  //       "<hr>\n" +
-  //       "Date: Fri, 23 Mar 2012 12:35:31 -0600<br>\n" +
-  //       "To: <a href=\"mailto:bob@example.com\">bob@example.com</a><br>\n" +
-  //       "From: <a href=\"mailto:rob@example.com\">rob@example.com</a><br>\n" +
-  //       "Subject: You Have New Mail From Mary!<br><br>\n\n" +
-  //       "text\n" +
-  //       "</div>\n" +
-  //       "</div>\n";
+    it("should detect reply with \"date\" block splitter.", function () {
+      const messageBody = "\n<div>" +
+        "message<br>\n" +
+        "<div>\n" +
+        "<hr>\n" +
+        "Date: Fri, 23 Mar 2012 12:35:31 -0600<br>\n" +
+        "To: <a href=\"mailto:bob@example.com\">bob@example.com</a><br>\n" +
+        "From: <a href=\"mailto:rob@example.com\">rob@example.com</a><br>\n" +
+        "Subject: You Have New Mail From Mary!<br><br>\n\n" +
+        "text\n" +
+        "</div>\n" +
+        "</div>\n";
 
-  //     const reply = "<html><body><div>message<br/></div></body></html>";
+      const reply = "<html><body><div>message<br/></div></body></html>";
 
 
-  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should detect reply with \"from\" block splitter.", function () {
-  //     const messageBody = `<div>
-  //       message<br>
-  //       <div>
-  //       <hr>
-  //       From: <a href="mailto:bob@example.com">bob@example.com</a><br>
-  //       Date: Fri, 23 Mar 2012 12:35:31 -0600<br>
-  //       To: <a href="mailto:rob@example.com">rob@example.com</a><br>
-  //       Subject: You Have New Mail From Mary!<br><br>
+    it("should detect reply with \"from\" block splitter.", function () {
+      const messageBody = `<div>
+        message<br>
+        <div>
+        <hr>
+        From: <a href="mailto:bob@example.com">bob@example.com</a><br>
+        Date: Fri, 23 Mar 2012 12:35:31 -0600<br>
+        To: <a href="mailto:rob@example.com">rob@example.com</a><br>
+        Subject: You Have New Mail From Mary!<br><br>
 
-  //       text
-  //       </div></div>`;
+        text
+        </div></div>`;
 
-  //     const reply = "<html><body><div>message<br/></div></body></html>";
+      const reply = "<html><body><div>message<br/></div></body></html>";
 
-  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
+      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
 
-  //   it("should detect reply with content in same element as \"from\" block splitter.", function () {
-  //     const messageBody = `
-  //       <body>
-  //         <div>
+    it("should detect reply with content in same element as \"from\" block splitter.", function () {
+      const messageBody = `
+        <body>
+          <div>
 
-  //           Blah<br><br>
+            Blah<br><br>
 
-  //           <hr>Date: Tue, 22 May 2012 18:29:16 -0600<br>
-  //           To: xx@hotmail.ca<br>
-  //           From: quickemail@ashleymadison.com<br>
-  //           Subject: You Have New Mail From x!<br><br>
+            <hr>Date: Tue, 22 May 2012 18:29:16 -0600<br>
+            To: xx@hotmail.ca<br>
+            From: quickemail@ashleymadison.com<br>
+            Subject: You Have New Mail From x!<br><br>
 
-  //         </div>
-  //       </body>`;
+          </div>
+        </body>`;
 
-  //     const reply = "<html><body><div>Blah<br/><br/></div></body></html>";
-  //     assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
-  //   });
-  // });
+      const reply = "<html><body><div>Blah<br/><br/></div></body></html>";
+      assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
+  });
 
-  // describe("Talon fixtures", function () {
+  describe("Talon fixtures", function () {
 
-  //   it("should find reply in OLK src body section.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "talon", "OLK_SRC_BODY_SECTION.html"), "utf-8", function (err, html) {
-  //       if (err)
-  //         return done(err);
+    it("should find reply in OLK src body section.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "talon", "OLK_SRC_BODY_SECTION.html"), "utf-8", function (err, html) {
+        if (err)
+          return done(err);
 
-  //       const reply = "<html><body><div>Reply</div></body></html>";
-  //       assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
-  //       done();
-  //     });
-  //   });
+        const reply = "<html><body><div>Reply</div></body></html>";
+        assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
+        done();
+      });
+    });
 
-  //   it("should find reply with <hr> separator.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "talon", "reply-separated-by-hr.html"), "utf-8", function (err, html) {
-  //       if (err)
-  //         return done(err);
+    it("should find reply with <hr> separator.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "talon", "reply-separated-by-hr.html"), "utf-8", function (err, html) {
+        if (err)
+          return done(err);
 
-  //       const reply = "<html><body><div>Hi<div>there</div><div>Bob<hr/><br/></div></div></body></html>";
-  //       assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
-  //       done();
-  //     });
-  //   });
+        const reply = "<html><body><div>Hi<div>there</div><div>Bob<hr/><br/></div></div></body></html>";
+        assert.equal(reply, removeWhitespace(quotations.extractFromHtml(html).body));
+        done();
+      });
+    });
 
-  //   it("should use fixtures to test ExtractFromHtml method.", function (done) {
-  //     // List the fixtures.
-  //     const htmlRepliesPath = path.join("tests", "fixtures", "talon", "html_replies");
-  //     return fs.readdir(htmlRepliesPath, (err, files) => {
-  //       if (err)
-  //         return done(err);
+    it("should use fixtures to test ExtractFromHtml method.", function (done) {
+      // List the fixtures.
+      const htmlRepliesPath = path.join("tests", "fixtures", "talon", "html_replies");
+      return fs.readdir(htmlRepliesPath, (err, files) => {
+        if (err)
+          return done(err);
 
-  //       // Iterate on the files we found.
-  //       return async.eachSeries(files, (file, nextFile) => {
+        // Iterate on the files we found.
+        return async.eachSeries(files, (file, nextFile) => {
 
-  //         // Read the file.
-  //         return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
-  //           if (err)
-  //             return nextFile(err);
+          // Read the file.
+          return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
+            if (err)
+              return nextFile(err);
 
-  //           const replyHtml = quotations.extractFromHtml(html).body;
-  //           const replyPlain = utils.htmlToText(replyHtml);
+            const replyHtml = quotations.extractFromHtml(html).body;
+            const replyPlain = utils.htmlToText(replyHtml);
 
-  //           assert.equal(
-  //             removeWhitespace("Hi. I am fine.\n\nThanks,\nAlex"),
-  //             removeWhitespace(replyPlain));
+            assert.equal(
+              removeWhitespace("Hi. I am fine.\n\nThanks,\nAlex"),
+              removeWhitespace(replyPlain));
 
-  //           return nextFile();
-  //         });
-  //       }, done);
-  //     });
-  //   });
-  // });
+            return nextFile();
+          });
+        }, done);
+      });
+    });
+  });
 
   describe("Nylas fixtures", function () {
 
@@ -331,131 +331,131 @@ describe("Html Quotations", function () {
     });
   });
 
-  // describe("Front fixtures", function () {
+  describe("Front fixtures", function () {
 
-  //   it("should correctly render Outlook comments.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_conditional_comments.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+    it("should correctly render Outlook comments.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_conditional_comments.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //       // Extract the quote.
-  //       var replyHtml = quotations.extractFromHtml(html).body;
+        // Extract the quote.
+        var replyHtml = quotations.extractFromHtml(html).body;
 
-  //       // Make sure it doesn't contain the incriminating string.
-  //       assert.notInclude(replyHtml, "<![if !supportLists]>", "The reply does not keep Word comments");
-  //       assert.notInclude(replyHtml, "&lt;![if !supportLists]>", "The reply does not transform Word comments");
-  //       done();
-  //     });
-  //   });
+        // Make sure it doesn't contain the incriminating string.
+        assert.notInclude(replyHtml, "<![if !supportLists]>", "The reply does not keep Word comments");
+        assert.notInclude(replyHtml, "&lt;![if !supportLists]>", "The reply does not transform Word comments");
+        done();
+      });
+    });
 
-  //   it("should correctly render emails with From: not followed by @ or Sent.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_from.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+    it("should correctly render emails with From: not followed by @ or Sent.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_from.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //       // Extract the quote.
-  //       var replyHtml = quotations.extractFromHtml(html).body;
+        // Extract the quote.
+        var replyHtml = quotations.extractFromHtml(html).body;
 
-  //       assert.include(replyHtml, "29 missing", "The reply does not cut From:");
-  //       done();
-  //     });
-  //   });
+        assert.include(replyHtml, "29 missing", "The reply does not cut From:");
+        done();
+      });
+    });
 
-  //   it("should correctly detect tables.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_table.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+    it("should correctly detect tables.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_table.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //       // Extract the quote.
-  //       var replyHtml = quotations.extractFromHtml(html).body;
+        // Extract the quote.
+        var replyHtml = quotations.extractFromHtml(html).body;
 
-  //       assert.equal(
-  //         removeWhitespace(utils.htmlToText(replyHtml)),
-  //         removeWhitespace(utils.htmlToText(html)));
-  //       done();
-  //     });
-  //   });
+        assert.equal(
+          removeWhitespace(utils.htmlToText(replyHtml)),
+          removeWhitespace(utils.htmlToText(html)));
+        done();
+      });
+    });
 
-  //   it("should not crash when no XmlDom document is found.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_no_doc.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+    it("should not crash when no XmlDom document is found.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_no_doc.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //       // Extract the quote.
-  //       quotations.extractFromHtml(html).body;
-  //       done();
-  //     });
-  //   });
+        // Extract the quote.
+        quotations.extractFromHtml(html).body;
+        done();
+      });
+    });
 
-  //   it("should correctly parse quotation.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_error_quote.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+    it("should correctly parse quotation.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_error_quote.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //       // Extract the quote.
-  //       const replyHtml = quotations.extractFromHtml(html).body;
-  //       assert.notInclude(replyHtml, "Bla");
-  //       return done();
-  //     });
-  //   });
+        // Extract the quote.
+        const replyHtml = quotations.extractFromHtml(html).body;
+        assert.notInclude(replyHtml, "Bla");
+        return done();
+      });
+    });
 
-  //   it("should correctly parse email with \n.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_error_line_break.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+    it("should correctly parse email with \n.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_error_line_break.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //       // Extract the quote.
-  //       const replyHtml = quotations.extractFromHtml(html).body;
-  //       assert.notInclude(replyHtml, "Hello from quote");
-  //       return done();
-  //     });
-  //   });
+        // Extract the quote.
+        const replyHtml = quotations.extractFromHtml(html).body;
+        assert.notInclude(replyHtml, "Hello from quote");
+        return done();
+      });
+    });
 
-  //   it("should correctly parse email with gmail quote in reply.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_quote.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+    it("should correctly parse email with gmail quote in reply.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_quote.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //        // Extract the quote.
-  //       const replyHtml = quotations.extractFromHtml(html).body;
-  //       assert.include(replyHtml, "Too often, how we work with people outside");
-  //       return done();
-  //     });
-  //   });
+         // Extract the quote.
+        const replyHtml = quotations.extractFromHtml(html).body;
+        assert.include(replyHtml, "Too often, how we work with people outside");
+        return done();
+      });
+    });
 
-  //      it("should correctly parse email with signature in reply.", function (done) {
-  //     return fs.readFile(path.join("tests", "fixtures", "front", "email_with_signature.html"), "utf-8", (err, html) => {
-  //       if (err)
-  //         return done(err);
+       it("should correctly parse email with signature in reply.", function (done) {
+      return fs.readFile(path.join("tests", "fixtures", "front", "email_with_signature.html"), "utf-8", (err, html) => {
+        if (err)
+          return done(err);
 
-  //        // Extract the quote.
-  //       const replyHtml = quotations.extractFromHtml(html).body;
-  //       assert.notInclude(replyHtml, "Leo Vck");
-  //       return done();
-  //     });
-  //   });
+         // Extract the quote.
+        const replyHtml = quotations.extractFromHtml(html).body;
+        assert.notInclude(replyHtml, "Leo Vck");
+        return done();
+      });
+    });
 
-  //   it("should test emails that used to crash extractFromHtml.", function (done) {
-  //     // List the fixtures.
-  //     const htmlRepliesPath = path.join("tests", "fixtures", "front", "crashers");
-  //     return fs.readdir(htmlRepliesPath, (err, files) => {
-  //       if (err)
-  //         return done(err);
+    it("should test emails that used to crash extractFromHtml.", function (done) {
+      // List the fixtures.
+      const htmlRepliesPath = path.join("tests", "fixtures", "front", "crashers");
+      return fs.readdir(htmlRepliesPath, (err, files) => {
+        if (err)
+          return done(err);
 
-  //       // Iterate on the files we found.
-  //       return async.eachSeries(files, (file, nextFile) => {
-  //         // Read the file.
-  //         return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
-  //           if (err)
-  //             return nextFile(err);
+        // Iterate on the files we found.
+        return async.eachSeries(files, (file, nextFile) => {
+          // Read the file.
+          return fs.readFile(path.join(htmlRepliesPath, file), "utf-8", (err, html) => {
+            if (err)
+              return nextFile(err);
 
-  //           quotations.extractFromHtml(html);
-  //           return nextFile();
-  //         });
-  //       }, done);
-  //     });
-  //   });
-  // });
+            quotations.extractFromHtml(html);
+            return nextFile();
+          });
+        }, done);
+      });
+    });
+  });
 
 });
 

--- a/tests/quotations_tests.js
+++ b/tests/quotations_tests.js
@@ -135,7 +135,7 @@ describe("Quotations", function () {
         ">On 04/19/2011 07:10 AM, Roman Tkachenko wrote:\n" +
         ">\n>>\n>> Test.\n>>\n>> Roman\n\n" +
         "Regards, Roman";
-      const reply = "Test reply\nRegards, Roman";
+      const reply = "Test reply\n\nRegards, Roman";
 
       assert.equal(reply, quotations.extractFromPlain(messageBody).body);
     });


### PR DESCRIPTION
This PR is trying to fix bug link to adding a quote messages in your reply.

Instead of starting by removing the quote from gmail, microsoft etc... We first attempt to remove the quote based on the regex. If no regex is found then use the blockquote.

This PR is increasing the minimum node and lines, as we don't remove the quote before checking the marked line we need to make sure the limit is high enough to check most of the emails.

New PR to set this as a param will come after this one.