### PR TITLE
PB 17319 — Don't crop middle of message

### DIFF
--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -14,13 +14,15 @@ import {
 } from './HtmlQuotations';
 import {
   CheckPointRegexp,
-  EmptyQuotationRegexp,
+  EmptyQuotationAfterSplitterRegexp,
+  EmptyQuotationBlockRegexp,
   ForwardRegexp,
   LinkRegexp,
   NormalizedLinkRegexp,
   OnDateSomebodyWroteRegexp,
   ParenthesisLinkRegexp,
-  QuotationRegexp,
+  QuotationAfterSplitterRegexp,
+  QuotationBlockRegexp,
   QuotePatternRegexp,
   SplitterRegexps,
 } from './Regexp';
@@ -378,8 +380,10 @@ export function processMarkedLines(lines: string[], markers: string): {
   }
 
   // Handle the case with markers.
-  quotation = markers.match(QuotationRegexp)
-    || markers.match(EmptyQuotationRegexp);
+  quotation = markers.match(QuotationAfterSplitterRegexp)
+     || markers.match(QuotationBlockRegexp)
+     || markers.match(EmptyQuotationAfterSplitterRegexp)
+     || markers.match(EmptyQuotationBlockRegexp);
 
   if (quotation) {
     const firstGroupStart = quotation.index + quotation[0].indexOf(quotation[1]);

--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -381,9 +381,9 @@ export function processMarkedLines(lines: string[], markers: string): {
 
   // Handle the case with markers.
   quotation = markers.match(QuotationAfterSplitterRegexp)
-     || markers.match(QuotationBlockRegexp)
-     || markers.match(EmptyQuotationAfterSplitterRegexp)
-     || markers.match(EmptyQuotationBlockRegexp);
+    || markers.match(QuotationBlockRegexp)
+    || markers.match(EmptyQuotationAfterSplitterRegexp)
+    || markers.match(EmptyQuotationBlockRegexp);
 
   if (quotation) {
     const firstGroupStart = quotation.index + quotation[0].indexOf(quotation[1]);

--- a/src/Regexp.ts
+++ b/src/Regexp.ts
@@ -81,7 +81,7 @@ export const QuotationBlockRegexp = new RegExp(
       "me*" +
     ")" +
     // After quotations should be nothing at all.
-    "[e]*$" +
+    "e*$" +
   ")"
 );
 
@@ -100,7 +100,7 @@ export const EmptyQuotationBlockRegexp = new RegExp(
     "(?:me*){2,}" +
   ")" +
   // Can only have empty lines after quotation.
-  "[e]*$"
+  "e*$"
 );
 
 // ------Original Message------ or ---- Reply Message ----

--- a/src/Regexp.ts
+++ b/src/Regexp.ts
@@ -55,34 +55,52 @@ export const OnDateWroteSomebodyRegexp = new RegExp(
   }).{0,100}:`
 );
 
-export const QuotationRegexp = new RegExp(
-  "(" +
-    // Quotation border: splitter line or a number of quotation marker lines.
-    "(?:" +
+export const QuotationAfterSplitterRegexp = new RegExp(
+  "(?:" +
+    "(" +
+      // Quotation border: splitter line.
       "s" +
-      "|" +
-      "(?:me*){2,}" +
+      // Quotation lines could be marked as splitter or text, etc.
+      ".*" +
+      // But we expect it to end with a quotation marker line.
+      "me*"+
     ")" +
-    // Quotation lines could be marked as splitter or text, etc.
-    ".*" +
-    // But we expect it to end with a quotation marker line.
-    "me*" +
-  ")" +
-
-  // After quotations should be text only or nothing at all.
-  "[te]*$"
+    // After quotations should be text only or nothing at all.
+    "[te]*$" +
+  ")"
 );
 
-export const EmptyQuotationRegexp = new RegExp(
-  "(" +
-    // Quotation border: splitter line or a number of quotation marker lines.
-    "(?:" +
-      "(?:se*)+" +
-      "|" +
+export const QuotationBlockRegexp = new RegExp(
+  "(?:" +
+    "(" +
+      // Quotation border: a number of quotation marker lines.
       "(?:me*){2,}" +
+      // Quotation lines could be marked as splitter or text, etc.
+      ".*" +
+      // But we expect it to end with a quotation marker line.
+      "me*" +
     ")" +
+    // After quotations should be nothing at all.
+    "[e]*$" +
+  ")"
+);
+
+export const EmptyQuotationAfterSplitterRegexp = new RegExp(
+  "(" +
+    // Quotation border: splitter line.
+    "(?:se*)+" +
   ")" +
+  // Can have empty lines after quotation.
   "e*"
+);
+
+export const EmptyQuotationBlockRegexp = new RegExp(
+  "(" +
+    // Quotation border: number of quotation marker lines.
+    "(?:me*){2,}" +
+  ")" +
+  // Can only have empty lines after quotation.
+  "[e]*$"
 );
 
 // ------Original Message------ or ---- Reply Message ----

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -237,6 +237,28 @@ describe("Html Quotations", function () {
       const reply = "<html><body><div>Blah<br/><br/></div></body></html>";
       assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
     });
+
+    it("should not remove quotes in middle of message", function () {
+      const messageBody = `
+        <html>
+            <body>
+              <div>Hello
+                <div><br /></div>
+                <div>I like to add quote in the middle of my message.</div>
+                <div><br /></div>
+                <div>&gt; First quote.</div>
+                <div>&gt; Second quote</div>
+                <div>&gt; Last quote.</div>
+                <div><br /></div>
+                <div>Please do not erase them. </div>
+                <div><br /></div>
+                <div>John Doe</div>
+              </div>
+            </body>
+        </html>`;
+
+      assert.equal(removeWhitespace(messageBody), removeWhitespace(quotations.extractFromHtml(messageBody).body));
+    });
   });
 
   describe("Talon fixtures", function () {


### PR DESCRIPTION
[JIRA](https://frontjira.atlassian.net/browse/PB-17319)

⛳ State the problem being solved.

In the following message, the lines starting by `>` were identified as quotations and were mistakenly cropped from the message's body. So they are hidden by default, unless the user clicks on the `...` button. 

![Kapture 2019-12-12 at 16 32 44](https://user-images.githubusercontent.com/429255/70725680-1d2ccb80-1cfd-11ea-962c-4ab3f9a7a588.gif)

Here is the underlying reason behind this bug: 

To find  quotation, we first use `markMessageLines` to identify the nature of its of each line. It returns a string where each char represents the nature of the line at its index in the message using the following code: 
- `t` for a line of text
- `m` for a line of quote (for example a line starting with `>`)
- `s` for a splitter
- `e` for an emtpy line

Example of output: `tesemmet`.

Then in `processMarkedLines`, we look for quotations pattern in this string using (among others) this regexp: `((?:s|(?:me*){2,}).*me*)[te]*$`. It looks for:
- A quotation border (`s|(?:me*){2,}`), in that case:
  - a splitter line
  - or a ininterrupted group of quotes line
- Followed by a almost anything until the end of the message `.*me*[te]*$` (it captures only until the last quote line though)

This means that indeed, a group of quotations line in the middle of a message (ie: preceded and followed by new text), will be identified as a quotation and will be cropped from the message body.

💭 Explain your solution and thought process.

Although it sounded reasonable to consider everything following a splitter like a quotation, it sounded a bit violent when it came to what follows a bunch of quotes line. 

In order to fix that I split this regexp into two regexp: 
- `(s.*me*).*$`: consider everything between a splitter and a quote line as a quotation. 
- `((?:me*){2,}.*me*)[e]*$`: consider everything between a group of quote lines and a quote line as a quotation if last quote line is followed by empty lines only (possibly zero).

`EmptyQuotationRegexp` was suffering from the same issue and I split it into two regexps following the same logic.

I added a test for the situation that caused the bug and all previously existing tests are still passing.

🌟 Highlight anything that is likely to raise questions, or that you want reviewers to pay special attention to.

This solution is not perfect as it will fail in the following case: 
```
Hello,
I like to add quotes in the middle of my message:
> this is 
> a quote on two lines

This is a very important sentence in my message.
> and I like to finish my message with a quote. 
```

But we have a specific test case for this situation that specifically expects this pattern to be identified as a quote: `should find quote with multi-line link 2.` So I'm tempted to leave it as it is for now considering that this a rare use case (don't know if we can rely on such gut feeling when it comes to mailing though).

<!-- 🙏 Do a self review, and then request a review from the right person! -->

<!-- 🤖 If you can, add tests to your PR, and if not, please tell why so we can improve the tests tooling! -->

<!-- 📔-->
<!-- https://github.com/frontapp/front-client/blob/master/docs/coding-guidelines.md -->
<!-- https://github.com/frontapp/front-client/blob/master/docs/contribution-guidelines.md -->
