### PR TITLE
Add german with Datum

### DIFF
--- a/src/Regexp.ts
+++ b/src/Regexp.ts
@@ -104,6 +104,7 @@ export const FromColonRegexp = new RegExp(
       "Van",
       "De",
       "Von",
+      "Von",
       "Fra",
       "Från"     // "From" in different languages.
     ].join("|")
@@ -113,6 +114,7 @@ export const FromColonRegexp = new RegExp(
       "Verzonden",
       "Envoyé",
       "Gesendet",
+      "Datum",
       "Sendt",
       "Skickat" ,
       "Enviada em"    // "Sent" in different languages.

--- a/tests/quotations_tests.js
+++ b/tests/quotations_tests.js
@@ -222,6 +222,17 @@ describe("Quotations", function () {
       assert.equal("Allo! Follow up MIME!", quotations.extractFromPlain(messageBody).body);
     });
 
+    it("should detect \"From\" block in German with Datum.", function () {
+      const messageBody = "Allo! Follow up MIME!\n\n" +
+        "Von: somebody@example.com\n" +
+        "An: Somebody\n" +
+        "Datum: Dienstag, 25. November 2014 14:59\n" +
+        "Betreff: The manager has commented on your Loop\n\n" +
+        "Blah-blah-blah\n";
+
+      assert.equal("Allo! Follow up MIME!", quotations.extractFromPlain(messageBody).body);
+    });
+
     it("should detect multiline \"From\" block in French.", function () {
       const messageBody = "Lorem ipsum\n\n" +
         "De : Brendan xxx [mailto:brendan.xxx@xxx.com]\n" +


### PR DESCRIPTION
Some german email are formated with Datum instead of Gesendet for the date.
```
Von:       XX
An:      xxx
Kopie:       xxx
Datum:        xx
Betreff: xx
```