### PR TITLE
Publish Typescript type declarations as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.23",
   "description": "Javascript port of the Mailgun/Talon library.",
   "main": "bin/Talon.js",
+  "types": "bin/Talon.d.ts",
   "repository": "https://github.com/quentez/talonjs",
   "scripts": {
-    "prepublish": "node node_modules/typescript/bin/tsc",
+    "prepublish": "node node_modules/typescript/bin/tsc -d",
     "pretest": "node node_modules/typescript/bin/tsc",
     "test": "node node_modules/mocha/bin/_mocha -t 20000 tests/*.js"
   },


### PR DESCRIPTION
Hello people from Front, I'm looking to use your port of Talon and I was missing the Typescript types declaration. It's an easy win to publish them with your package.