### PR TITLE
Use content type "text/html" when preprocessing an HTML message

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -12,7 +12,7 @@ export const QuoteIds = ["OLK_SRC_BODY_SECTION"];
 export const CheckpointPrefix = "#!%!";
 export const CheckpointSuffix = "!%!#";
 
-export const BlockTags = ["div", "p", "ul", "li", "h1", "h2", "h3"];
+export const BlockTags = ["blockquote", "div", "p", "ul", "li", "h1", "h2", "h3"];
 export const HardbreakTags = ["br", "hr", "tr"];
 
 export enum NodeTypes {

--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -1,7 +1,15 @@
 import * as Cheerio from 'cheerio';
 import * as XmlDom from 'xmldom';
 
-import { ContentType, ContentTypeTextPlain, DefaultMaxLinesCount, DefaultNodeLimit, SplitterMaxLines, NodeTypes } from './Constants';
+import {
+  ContentType,
+  ContentTypeTextHtml,
+  ContentTypeTextPlain,
+  DefaultMaxLinesCount,
+  DefaultNodeLimit,
+  NodeTypes,
+  SplitterMaxLines
+} from './Constants';
 import {
   addCheckpoint,
   cutBlockquote,
@@ -197,7 +205,7 @@ function extractQuoteHtmlViaMarkers(numberOfCheckpoints: number, xmlDocument: Do
     ...options
   }
 
-  const messagePlainText = preprocess(elementToText(xmlDocument, {ignoreBlockTags}), "\n", ContentTypeTextPlain);
+  const messagePlainText = preprocess(elementToText(xmlDocument, {ignoreBlockTags}), "\n", ContentTypeTextHtml);
   let lines = splitLines(messagePlainText);
 
   // Stop here if the message is too long.

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -238,6 +238,46 @@ describe("Html Quotations", function () {
       assert.equal(reply, removeWhitespace(quotations.extractFromHtml(messageBody).body));
     });
 
+    it("should not find splitter lines in the middle of reply", function () {
+      const messageBody = `
+        <html>
+          <body>
+            <div dir=\"ltr\"><div>Resending this:</div>
+              <div dir=\"ltr\"><br></div>
+              <div dir=\"ltr\">
+                Hi Recipient,
+                <div><br></div>
+                <div>Thanks for following up.</div><div><br></div>
+                <div>I actually wanted to reach out about the info you provided: </div>
+                <div>
+                  <ul>
+                    <li>On the previous two occasions, when David sent us the photos, only the blue sloth was available for adoption.</li>
+                    <li>This list, with the additional requested information, would be nice.</li>
+                    <li>And yes, we can add a gift note to the box.</li>
+                  </ul>
+                  <div>Also, would you like to purchase a frame?</div>
+                  <div><br></div>
+                  <div>Best,</div>
+                  <div class=\"gmail_quote\">
+                    <div dir=\"ltr\" class=\"gmail_attr\"><br></div>
+                    <div><br></div>
+                    -- <br>
+                    <div dir=\"ltr\" class=\"gmail_signature\"><div><div dir=\"ltr\">Signature</div></div></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        </html>
+      `;
+
+      // Extract the quote.
+      const replyHtml = quotations.extractFromHtml(messageBody).body;
+
+      assert.include(replyHtml, "On the previous two occasions", "The reply does not cut message content that resembles a splitter line");
+      assert.include(replyHtml, "Best,", "The reply does not cut the line before the signature");
+    });
+
     it("should not remove quotes in middle of message", function () {
       const messageBody = `
         <html>


### PR DESCRIPTION
This change ensures that we pass the correct content-type to `preprocess` when extracting a reply from HTML.

When preprocessing a plain text document, we search for the `OnDateSomebodyWroteRegexp` [anywhere in the message body](https://github.com/quentez/talonjs/blob/master/src/Quotations.ts#L255) instead of matching it only on the beginning of a line. This means that it's easier to find false positives in the reply content - any sentence that matches the pattern "On ..., ... wrote/sent ..." If processing an HTML doc, we can afford to be a bit stricter, and only match that regexp on the beginning of a line. (Incidentally, this is [equivalent to what mailgun/talon does](https://github.com/mailgun/talon/blob/master/talon/quotations.py#L479).)

As a consequence of this change, however, a Nylas test started failing on the fixture `email_15.html`. This is because we previously expected to find a splitter in the middle of a line comprised of two `blockquote` tags:

`#!%!12!%!# #!%!13!%!##!%!16!%!# Some text in an inline quote#!%!14!%!##!%!15!%!# On Jan 1 2020, at 12:34 pm, user@example.com <user@example.com> wrote: #!%!17!%!##!%!222!%!# #!%!18!%!#`.

Now that we only match the `OnDateSomebodyWroteRegexp` on the start of a line, that's no longer the case.

Instead, this PR adds `<blockquote>` to the list of tags that we automatically append a newline char to when converting an XML document to text. The same line is then split into two:
```
#!%!13!%!##!%!16!%!#
Some text in an inline quote#!%!14!%!##!%!15!%!#
On Jan 1 2020, at 12:34 pm, user@example.com <user@example.com> wrote: #!%!17!%!##!%!222!%!# #!%!18!%!#
```

This fixes the failing test.

## Alternatives considered
- The `OnDateSomebodyWroteRegexp` is fairly loosely defined - we could instead/also work on making it stricter.