### PR TITLE
Add new property `usingCheckpoints` to ExtractFromHtmlResult

### DIFF
--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -90,7 +90,8 @@ interface ExtractFromHtmlOptions {
 }
 
 interface ExtractFromHtmlResult extends ExtractFromPlainResult {
-  isTooLong?: boolean
+  isTooLong?: boolean,
+  didUseCheckpoints?: boolean
 }
 
 /**
@@ -135,7 +136,11 @@ export function extractFromHtml(messageBody: string, options?: ExtractFromHtmlOp
   }
 
   // If that still didn't work, just use the stripped down version as-is.
-  return { body: xmlDomSerializer.serializeToString(xmlDocument, true), didFindQuote: true };
+  return {
+    body: xmlDomSerializer.serializeToString(xmlDocument, true),
+    didFindQuote: true,
+    didUseCheckpoints: false
+  };
 }
 
 function extractQuotationUsingCheckpoints(xmlDocument: Document, messageBody: string, options?: ExtractFromHtmlOptions): ExtractFromHtmlResult {
@@ -175,7 +180,8 @@ function extractQuotationUsingCheckpoints(xmlDocument: Document, messageBody: st
   // Serialize and return.
   return {
     body: xmlDomSerializer.serializeToString(xmlDocument, true),
-    didFindQuote: true
+    didFindQuote: true,
+    didUseCheckpoints: true
   }
 }
 

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -142,9 +142,11 @@ describe("Html Quotations", function () {
         "</div>" +
         "</blockquote>";
 
+      const result = quotations.extractFromHtml(messageBody);
       assert.equal(
         removeWhitespace("<html><body>Message</body></html>"),
-        removeWhitespace(quotations.extractFromHtml(messageBody).body));
+        removeWhitespace(result.body));
+      assert.isFalse(result.didUseCheckpoints);
     });
 
     it("should detect reply with disclaimer after quote.", function () {
@@ -177,9 +179,9 @@ describe("Html Quotations", function () {
         "</body>\n" +
         "</html>\n";
 
-      assert.equal(
-        removeWhitespace(reply),
-        removeWhitespace(quotations.extractFromHtml(messageBody).body));
+      const result = quotations.extractFromHtml(messageBody);
+      assert.equal(removeWhitespace(reply), removeWhitespace(result.body));
+      assert.isFalse(result.didUseCheckpoints);
     });
 
     it("should detect reply with \"date\" block splitter.", function () {
@@ -550,6 +552,21 @@ describe("Html Quotations", function () {
         assert.include(replyHtml, "Too often, how we work with people outside");
         return done();
       });
+    });
+
+    it.skip("should not cut an inline blockquote from reply", function () {
+      const messageBody = `
+        <blockquote>
+          <p>What is your plan for X?</p>
+        </blockquote>
+        <p>I was planning on doing this in a separate PR, but it makes sense to add it here, so I'll just update this PR.</p>
+        <p style=\"font-size:small;-webkit-text-size-adjust:none;color:#666;\">&mdash;<br />You are receiving this because your review was requested.<br />Reply to this email directly, <a href=\"https://github.com/">unsubscribe</a>.</p>
+      `;
+
+       // Extract the quote.
+      const result = quotations.extractFromHtml(messageBody);
+      assert.include(result.body, "What is your plan for X?");
+      assert.isFalse(result.didFindQuote, "didFindQuote");
     });
 
     it("should correctly parse email with signature in reply.", function (done) {

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -554,21 +554,6 @@ describe("Html Quotations", function () {
       });
     });
 
-    it.skip("should not cut an inline blockquote from reply", function () {
-      const messageBody = `
-        <blockquote>
-          <p>What is your plan for X?</p>
-        </blockquote>
-        <p>I was planning on doing this in a separate PR, but it makes sense to add it here, so I'll just update this PR.</p>
-        <p style=\"font-size:small;-webkit-text-size-adjust:none;color:#666;\">&mdash;<br />You are receiving this because your review was requested.<br />Reply to this email directly, <a href=\"https://github.com/">unsubscribe</a>.</p>
-      `;
-
-       // Extract the quote.
-      const result = quotations.extractFromHtml(messageBody);
-      assert.include(result.body, "What is your plan for X?");
-      assert.isFalse(result.didFindQuote, "didFindQuote");
-    });
-
     it("should correctly parse email with signature in reply.", function (done) {
       return fs.readFile(path.join("tests", "fixtures", "front", "email_with_signature.html"), "utf-8", (err, html) => {
         if (err)


### PR DESCRIPTION
Adds an optional new property to `ExtractFromHtmlResult` to indicate whether a quote was found using checkpoints or by a more brute-force way of [stripping out known quotation tags](https://github.com/quentez/talonjs/blob/master/src/Quotations.ts#L117). The goal is to enable gathering more data about how often this results in false positives (removing quotes that should be considered part of the reply). The property is only added when `didFindQuote` is true.

Also adds a failing/skipped test for one known case of this type of false positive.