### PR TITLE
Improve detection of forwarded messages

### DIFF
--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -233,7 +233,7 @@ function extractQuoteHtmlViaMarkers(numberOfCheckpoints: number, xmlDocument: Do
       for (let checkpoint of lineCheckpoints[index])
         quotationCheckpoints[checkpoint] = true;
 
-  return {quoteWasFound: wereLinesDeleted, quotationCheckpoints: quotationCheckpoints}
+  return {quoteWasFound: wereLinesDeleted, quotationCheckpoints }
 }
 
 /*
@@ -306,7 +306,7 @@ export function markMessageLines(lines: string[]): string {
     } else if (matchStart(line, QuotePatternRegexp)) {
       markers[index] = "m";
     // Forwarded message.
-    } else if (matchStart(line, ForwardRegexp)) {
+    } else if (matchStart(line.trim(), ForwardRegexp)) {
       markers[index] = "f";
     } else {
       // Try to find a splitter spread on several lines.
@@ -352,10 +352,12 @@ export function processMarkedLines(lines: string[], markers: string): {
     firstDeletedLine: -1,
     lastDeletedLine: -1
   };
+
   // If there are no splitters, there should be no markers.
   if (markers.indexOf("s") < 0 && !/(me*){3}/.exec(markers))
     markers = markers.replace(/m/g, "t");
 
+  // Return forwarded messages intact (do not delete any lines)
   if (matchStart(markers, /[te]*f/))
     return result;
 

--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -300,6 +300,34 @@ describe("Html Quotations", function () {
       assert.equal(removeWhitespace(messageBody), removeWhitespace(quotations.extractFromHtml(messageBody).body));
     });
 
+    it("should not cut forwarded messages from the reply", function () {
+      const messageBody = `
+        <html>
+          <body>
+            <div><br><br>Sent from my iPad</div>
+            <div><br>--- Forwarded message ---<br><br></div>
+            <blockquote type=\"cite\">
+              <div><b>From:</b> Ms. Smith &lt;<a href=\"mailto:mssmith123@gmail.com\">mssmith123@gmail.com</a>&gt;<br><b>Date:</b> November 12, 2019 at 3:27:21 PM EST<br><b>To:</b> <a href=\"mailto:support@company.com\">support@company.com</a><br><b>Subject:</b> <b>This is the subject</b><br><br></div>
+            </blockquote>
+            <div><span></span></div><blockquote type=\"cite\"><div><span>Here are the screenshots.</span><br><span></span><br></div></blockquote>
+            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
+            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
+            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
+            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
+            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
+            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
+            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
+            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span>Sent from my iPhone</span></div></blockquote>
+          </body>
+        </html>
+      `;
+
+      const replyHtml = quotations.extractFromHtml(messageBody).body;
+      assert.include(replyHtml, "Sent from my iPad", "The reply preserves the signature");
+      assert.include(replyHtml, "Forwarded message", "The reply does not cut the splitter line");
+      assert.include(replyHtml, "Here are the screenshots", "The forwarded content is not cut from the reply");
+    });
+
     it("should not crop whole message when it contains img only.", function () {
       const messageBody = `
         <html>


### PR DESCRIPTION
Identify more messages as forwards by trimming whitespace from `--- Forwarded message ---` lines before applying the ForwardRegexp.

The intended behavior of talonjs is to consider a forwarded message part of the reply. It does this by checking if the message begins with any number of text markers or empty lines, followed by a line that matches the [ForwardRegexp](https://github.com/quentez/talonjs/blob/master/src/Regexp.ts#L7). If it does, then talonjs [returns the message intact](https://github.com/quentez/talonjs/blob/master/src/Quotations.ts#L359), without cutting any lines.

In practice, this hasn't been applied if the line is bookended by whitespace or followed by a newline character. In those cases, the forwarded content has been parsed as quoted text and removed from the reply. (However, since the `--- Forwarded message ---` does not match any of the splitter regexes, it's been preserved as part of the reply.) This PR fixes that by applying `.trim()` to the line before trying to match it against the regexp.

## Alternatives considered
I almost changed the ForwardRegexp to allow for trailing whitespace instead of using `trim()`, but thought that this would be clearer (and we already call `trim()` on the line earlier in the same function).