### PR TITLE
Return forwarded messages intact (without removing the forwarded content)

### DIFF
--- a/tests/html_quotations_tests.js
+++ b/tests/html_quotations_tests.js
@@ -302,34 +302,6 @@ describe("Html Quotations", function () {
       assert.equal(removeWhitespace(messageBody), removeWhitespace(quotations.extractFromHtml(messageBody).body));
     });
 
-    it("should not cut forwarded messages from the reply", function () {
-      const messageBody = `
-        <html>
-          <body>
-            <div><br><br>Sent from my iPad</div>
-            <div><br>--- Forwarded message ---<br><br></div>
-            <blockquote type=\"cite\">
-              <div><b>From:</b> Ms. Smith &lt;<a href=\"mailto:mssmith123@gmail.com\">mssmith123@gmail.com</a>&gt;<br><b>Date:</b> November 12, 2019 at 3:27:21 PM EST<br><b>To:</b> <a href=\"mailto:support@company.com\">support@company.com</a><br><b>Subject:</b> <b>This is the subject</b><br><br></div>
-            </blockquote>
-            <div><span></span></div><blockquote type=\"cite\"><div><span>Here are the screenshots.</span><br><span></span><br></div></blockquote>
-            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
-            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
-            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
-            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
-            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
-            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
-            <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
-            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span>Sent from my iPhone</span></div></blockquote>
-          </body>
-        </html>
-      `;
-
-      const replyHtml = quotations.extractFromHtml(messageBody).body;
-      assert.include(replyHtml, "Sent from my iPad", "The reply preserves the signature");
-      assert.include(replyHtml, "Forwarded message", "The reply does not cut the splitter line");
-      assert.include(replyHtml, "Here are the screenshots", "The forwarded content is not cut from the reply");
-    });
-
     it("should not crop whole message when it contains img only.", function () {
       const messageBody = `
         <html>
@@ -369,6 +341,57 @@ describe("Html Quotations", function () {
       const computedLightBody = quotations.extractFromHtml(messageBody).body;
 
       assert.equal(removeWhitespace(expectedLightBody), removeWhitespace(computedLightBody));
+    });
+  });
+
+  describe("Forwarded messages", function () {
+
+    const forwardedMessage = `
+      <div><br><br>Sent from my iPad</div>
+      <div><br>--- Forwarded message ---<br><br></div>
+      <blockquote type=\"cite\">
+        <div><b>From:</b> Ms. Smith &lt;<a href=\"mailto:mssmith123@gmail.com\">mssmith123@gmail.com</a>&gt;<br><b>Date:</b> November 12, 2019 at 3:27:21 PM EST<br><b>To:</b> <a href=\"mailto:support@company.com\">support@company.com</a><br><b>Subject:</b> <b>This is the subject</b><br><br></div>
+      </blockquote>
+      <div><span></span></div><blockquote type=\"cite\"><div><span>Here are the screenshots.</span><br><span></span><br></div></blockquote>
+      <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
+      <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
+      <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
+      <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
+      <blockquote type=\"cite\"><div><img src=\"\" id=\"\" style=\"padding:0px 1px 1px 0px;\"></div></blockquote>
+      <blockquote type=\"cite\"><div><span></span><br><span></span><br><span></span><br></div></blockquote>
+    `;
+
+    it("should not cut forwarded messages from the reply", function () {
+      const messageBody = `
+        <html>
+          <body>
+            ${forwardedMessage};
+          </body>
+        </html>
+      `;
+
+      const result = quotations.extractFromHtml(messageBody);
+      assert.isFalse(result.didFindQuote, "No quote found if the message was forwarded");
+      assert.isTrue(result.didUseCheckpoints, "We did not try cutting all quotation tags");
+
+      const replyHtml = result.body;
+      assert.include(replyHtml, "Sent from my iPad", "The reply preserves the signature");
+      assert.include(replyHtml, "Forwarded message", "The reply does not cut the splitter line");
+      assert.include(replyHtml, "Here are the screenshots", "The forwarded content is not cut from the reply");
+    });
+
+    it("should not cut a blockquote from inside a forwarded message", function () {
+      const messageBody = `
+        <html>
+          <body>
+            ${forwardedMessage};
+            <blockquote type=\"cite\"><div><span></span><br><span></span><br><span>Sent from my iPhone</span></div></blockquote>
+          </body>
+        </html>
+      `;
+
+      const replyHtml = quotations.extractFromHtml(messageBody).body;
+      assert.include(replyHtml, "Sent from my iPhone", "The signature from the forwarded message is not cut either");
     });
   });
 


### PR DESCRIPTION
Follow-up to #36: if we find that a message was forwarded, we stop processing it and return it intact; we also avoid using the non-checkpoints method to find quotes.

> The intended behavior of talonjs is to consider a forwarded message part of the reply. It does this by checking [if the message begins with any number of text markers or empty lines, followed by a line that matches the ForwardRegexp](https://github.com/quentez/talonjs/blob/master/src/Quotations.ts#L367). If it does, then talonjs returns the message intact, without cutting any lines.

However, because talonjs will, as a last resort, strip out all known quotation tags if a quote isn't found by using the checkpoints method, this means that parts of forwarded messages (for which `didFindQuote` is always false) are still cut from the reply. (I've added a regression test to catch this: https://github.com/quentez/talonjs/compare/kh/preserve-forwards?expand=1#diff-0b32b5b5092982e9deccf54f38fa8763R383.)