### PR TITLE
Update ForwardRegexp to handle iOS-style forwarding line

### DIFF
--- a/src/HtmlQuotations.ts
+++ b/src/HtmlQuotations.ts
@@ -1,8 +1,7 @@
 import * as XPath from 'xpath';
 
 import { CheckpointPrefix, CheckpointSuffix, QuoteIds, NodeTypes, DefaultNodeLimit } from './Constants';
-import { ForwardRegexp } from './Regexp';
-import { matchStart } from './Utils';
+import { isStartOfForwardedMessage, matchStart } from './Utils';
 
 
 export interface AddCheckpointOptions {
@@ -165,7 +164,7 @@ export function cutGmailQuote(document: Document, options?: CutQuoteOptions): bo
   const gmailQuote = <Node>XPath.select("//*[contains(@class, 'gmail_quote')]", document, true);
 
   // If no quote was found, or if that quote was a forward, return false.
-  if (!gmailQuote || (gmailQuote.textContent && matchStart(gmailQuote.textContent, ForwardRegexp)) || shouldNotRemoveQuote(gmailQuote, options))
+  if (!gmailQuote || (gmailQuote.textContent && isStartOfForwardedMessage(gmailQuote.textContent)) || shouldNotRemoveQuote(gmailQuote, options))
     return false;
 
   // Otherwise, remove the quote from the document and return.

--- a/src/Quotations.ts
+++ b/src/Quotations.ts
@@ -24,7 +24,6 @@ import {
   CheckPointRegexp,
   EmptyQuotationAfterSplitterRegexp,
   EmptyQuotationBlockRegexp,
-  ForwardRegexp,
   LinkRegexp,
   NormalizedLinkRegexp,
   OnDateSomebodyWroteRegexp,
@@ -34,7 +33,7 @@ import {
   QuotePatternRegexp,
   SplitterRegexps,
 } from './Regexp';
-import { elementToText, findDelimiter, matchStart, normalizeHtmlDocument, splitLines } from './Utils';
+import { elementToText, findDelimiter, isStartOfForwardedMessage, matchStart, normalizeHtmlDocument, splitLines } from './Utils';
 
 const xmlDomParser = new XmlDom.DOMParser({ errorHandler: { warning: () => {}, error: () => {}, fatalError: (error) => { throw error; } }});
 const xmlDomSerializer = new XmlDom.XMLSerializer();
@@ -323,7 +322,7 @@ export function markMessageLines(lines: string[]): string {
     } else if (matchStart(line, QuotePatternRegexp)) {
       markers[index] = "m";
     // Forwarded message.
-    } else if (matchStart(line.trim(), ForwardRegexp)) {
+    } else if (isStartOfForwardedMessage(line)) {
       markers[index] = "f";
     } else {
       // Try to find a splitter spread on several lines.

--- a/src/Regexp.ts
+++ b/src/Regexp.ts
@@ -4,7 +4,7 @@ export const CheckPointRegexp = new RegExp(`${CheckpointPrefix}\\d+${CheckpointS
 
 export const DelimiterRegexp = new RegExp("\\r?\\n");
 
-export const ForwardRegexp = new RegExp("^[-]+[ ]*Forwarded message[ ]*[-]+$", "im");
+export const ForwardRegexp = new RegExp("^[-\\w]+[ ]*Forwarded message(:|[ ]*-+)$", "im");
 
 export const OnDateSomebodyWroteRegexp = new RegExp(
   `-{0,100}[>]?[\\s]?(${

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,7 +1,7 @@
 import * as XPath from 'xpath';
 
 import { BlockTags, HardbreakTags, NodeTypes } from './Constants';
-import { DelimiterRegexp } from './Regexp';
+import { DelimiterRegexp, ForwardRegexp } from './Regexp';
 
 /**
  * Find the line delimiter in the specified message body.
@@ -20,6 +20,15 @@ export function findDelimiter(messageBody: string): string {
  */
 export function splitLines(str: string): string[] {
   return str.split(/\r?\n/);
+};
+
+/**
+ * Return true if the ForwardRegexp matches the start of the given string.
+ * @param {string} str - The base string.
+ * @return {RegExpMatchArray} The resulting match, if any.
+ */
+export function isStartOfForwardedMessage(str: string): boolean {
+  return Boolean(matchStart(str.trim(), ForwardRegexp));
 };
 
 /**

--- a/tests/regexp.js
+++ b/tests/regexp.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const async = require("front-async");
+const assert = require("chai").assert;
+const utils = require("./utils");
+const { isStartOfForwardedMessage } = require("../bin/Talon").utils;
+
+describe("TalonJS Regexp", function () {
+
+  describe("ForwardRegexp", function () {
+
+    const matchingLines = [
+      "----- Forwarded message -----\n", // Gmail
+      "Begin forwarded message:"         // iOS
+    ];
+
+    it("should match the following lines", function () {
+      for (const line of matchingLines) {
+        assert.isTrue(isStartOfForwardedMessage(line), line);
+      }
+    });
+
+    const nonMatchingLines = [
+      "Sally forwarded this message",
+      "See forwarded message below:"
+    ];
+
+    it("should not match the following lines", function () {
+      for (const line of nonMatchingLines)
+        assert.isFalse(isStartOfForwardedMessage(line), line);
+    });
+  });
+});


### PR DESCRIPTION
- Updates the regexp used to detect forwarded messages to allow for the usual iOS format ("Begin forwarded message:").
- Adds a new regexp test file