### PR TITLE
Add new option to disallow brute-force removal of quotation tags

### DIFF
--- a/src/HtmlQuotations.ts
+++ b/src/HtmlQuotations.ts
@@ -270,7 +270,7 @@ export function cutById(document: Document, options?: CutQuoteOptions): boolean 
 };
 
 /**
- * Cust the last non-nested blockquote with wrapping elements.
+ * Cuts the last non-nested blockquote with wrapping elements.
  *
  * @param {Document} document - The document to cut the element from.
  * @param {CutQuoteOptions} options - Extra options.

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -100,13 +100,13 @@ export function elementToText(element: Node, {ignoreBlockTags}: ElementToTextOpt
 
 function extractTextFromNode(node: Node, text: String) {
   let nodeValue = (node.nodeValue || (node.firstChild && node.firstChild.nodeType === NodeTypes.TEXT_NODE && node.firstChild.nodeValue) || '').trim();
-  const sibillingValue = ((node.nextSibling && node.nextSibling.nodeType === NodeTypes.TEXT_NODE && node.nextSibling.nodeValue) || '').trim();
+  const siblingValue = ((node.nextSibling && node.nextSibling.nodeType === NodeTypes.TEXT_NODE && node.nextSibling.nodeValue) || '').trim();
 
   if (HardbreakTags.indexOf(node.nodeName.toLowerCase()) >= 0
     && text && text[text.length - 1] !== "\n")
     nodeValue += "\n";
 
-  let nodeText = nodeValue + sibillingValue;
+  let nodeText = nodeValue + siblingValue;
   return nodeText.replace('\\n', '\n');
 }
 


### PR DESCRIPTION
Adds an option to `extractFromHtml` to avoid cutting known quotation tags when otherwise no quoted text is found, **unless** the original message body was too large to process using checkpoints without doing so.

## Risks
- If this option is enabled, it will certainly increase cases of under-collapsed message history (but we can use that as an opportunity to improve the splitter detection and expand language support).
- Otherwise, this is low-risk since TalonJS will continue to behave the same unless the new option is used.

## Alternatives considered
- Adding additional heuristics to `cutQuotation` (such as not cutting the quote if there was only one found, or not cutting the quote if it's the first text node)
- Making the option default to true (= a breaking change)


